### PR TITLE
OPCUA-654 safe ownership passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 CMakeFiles
 Makefile
+include/open62541.h
+src/open62541.c
+open62541/
+cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,5 @@
 add_library ( open62541-compat OBJECT
   src/nodemanagerbase.cpp
   src/open62541_compat.cpp
-  src/open62541.c
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,6 @@
 add_library ( open62541-compat OBJECT
   src/nodemanagerbase.cpp
   src/open62541_compat.cpp
-  
+  src/open62541.c
   )
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # open62541-compat
 Adapts open62541 API to UA Toolkit API for usage in Quasar-based projects
+
+Quick-start guide:
+1) Enable this module (open62541-compat) in your quasar project
+
+./quasar.py enable_module open62541-compat
+
+2) In order to fetch open62541 and build it, execute:
+
+./prepare.sh
+
+
+For bugs or suggestions contact piotr.nikiel@cern.ch

--- a/include/nodemanagerbase.h
+++ b/include/nodemanagerbase.h
@@ -41,16 +41,11 @@ class NodeManagerConfig
 class NodeManagerBase: public NodeManagerConfig
 {
 public:
-	NodeManagerBase( const char* name, bool sth, int hashtablesize ) { m_server = 0; m_namespace = 0; }
+	NodeManagerBase( const char* uri, bool sth, int hashtablesize );
 	virtual ~NodeManagerBase();
 	UaNode* getNode( const UaNodeId& nodeId ) const;
 
-	// int getNameSpaceIndex () const { return 1; }
-	int getNameSpaceIndex () const {
-		// Index 0 is reserved for the open6, and index 2 for all added stuff. 1 seems unused.
-		return( m_namespace );
-	}
-	//int getNameSpaceIndex () const { return 2; }
+	OpcUa_UInt16 getNameSpaceIndex 	() 	const { return 2; }
 
 	UaStatus addNodeAndReference( 
 			const UaNodeId& from,
@@ -61,19 +56,13 @@ public:
 			UaNode* to,
 			const UaNodeId& refType); // { return addNodeAndReference( from->nodeId(), to, refType ); }
 
-	void linkServer( UA_Server* s ) { m_server = s; }
+	void linkServer( UA_Server* server );
 
-
-	bool setNamespace( const int ns, const std::string &nsName ){
-		m_namespace  = ns;
-		const int nsIndex = UA_Server_addNamespace( m_server, nsName.c_str() );
-		return ( nsIndex == ns );
-	}
 
 private:
 	UA_Server* m_server;
 	std::list<UaNode*> m_listNodes;
-		int m_namespace;
+	std::string m_nameSpaceUri;
 
 		class ServerRootNode: public UaNode
 		{

--- a/include/opcua_basedatavariabletype.h
+++ b/include/opcua_basedatavariabletype.h
@@ -47,7 +47,7 @@ namespace OpcUa
 	    const UaDataValue& dataValue,
 	    OpcUa_Boolean checkAccessLevel
 	    );
-	virtual UaDataValue value(Session* session) const;
+	virtual UaDataValue value(Session* session) ;
 	virtual UaQualifiedName browseName() const { return m_browseName; }
 	virtual UaNodeId typeDefinitionId() const { return UaNodeId(UA_NS0ID_BASEDATAVARIABLETYPE,0); }
 	virtual void setDataType( const UaNodeId& typeref ) {}

--- a/include/uavariant.h
+++ b/include/uavariant.h
@@ -24,6 +24,7 @@
 
 #include <opcua_platformdefs.h>
 #include <open62541.h>
+#include <atomic>
 
 enum OpcUaType
   {
@@ -116,8 +117,12 @@ class UaDataValue
     const UA_DataValue* impl() const { return m_impl; }
     UaVariant* value() const{ return new UaVariant(m_impl->value); }
 
+    UaDataValue clone(); // can't be const because of synchronization
+
   private:
     UA_DataValue *m_impl;
+    std::atomic_flag m_lock;
+    
   
   											 
 };

--- a/include/uavariant.h
+++ b/include/uavariant.h
@@ -24,7 +24,16 @@
 
 #include <opcua_platformdefs.h>
 #include <open62541.h>
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                               + __GNUC_MINOR__ * 100 \
+                               + __GNUC_PATCHLEVEL__)
+#if GCC_VERSION > 48000
 #include <atomic>
+#else
+#include <stdatomic.h>
+#endif
+
 
 enum OpcUaType
   {

--- a/include/uavariant.h
+++ b/include/uavariant.h
@@ -25,6 +25,8 @@
 #include <opcua_platformdefs.h>
 #include <open62541.h>
 
+#ifdef __linux__
+
 #define GCC_VERSION (__GNUC__ * 10000 \
                                + __GNUC_MINOR__ * 100 \
                                + __GNUC_PATCHLEVEL__)
@@ -32,6 +34,10 @@
 #include <atomic>
 #else
 #include <stdatomic.h>
+#endif
+
+#else // other than Linux, i.e. Windows
+#include <atomic>
 #endif
 
 

--- a/prepare.py
+++ b/prepare.py
@@ -61,7 +61,7 @@ def main():
 		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../')
 		subprocess.check_call(['cmake', '-DUA_ENABLE_AMALGAMATION=ON', '../'])
 		print('make')
-		subprocess.check_call(['make'], stdout=out)
+		subprocess.check_call(['make'])
 		
 	shutil.copyfile(os.path.join(open6BuildDir, 'open62541.h'), os.path.join(baseDir, 'include', 'open62541.h'))
 	shutil.copyfile(os.path.join(open6BuildDir, 'open62541.c'), os.path.join(baseDir, 'src', 'open62541.c'))

--- a/prepare.py
+++ b/prepare.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+'''
+@author:     Damian Abalo Miron <damian.abalo@cern.ch>
+@copyright:  2015 CERN
+@license:
+Copyright (c) 2015, CERN, Universidad de Oviedo.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+@contact:    damian.abalo@cern.ch
+'''
+
+import os
+import sys
+import shutil
+import platform
+import subprocess
+from shutil import copyfile
+
+def deleteFolderRecursively( topdir, target ):
+	for dirpath, dirnames, files in os.walk(topdir):
+		for name in dirnames:
+			if name == target:
+				try:
+					shutil.rmtree(os.path.join(dirpath, name))
+				except OSError:
+					pass
+	return;
+def deleteFileRecursively( topdir, target ):
+	for dirpath, dirnames, files in os.walk(topdir):
+		for name in files:
+			if name == target:
+				try:
+					os.remove(os.path.join(dirpath, name))					
+				except OSError:
+					pass
+	return;
+	
+def main():
+	deleteFolderRecursively('.', 'open62541')
+	print('git clone https://github.com/open62541/open62541.git')
+	subprocess.call(['git', 'clone', 'https://github.com/open62541/open62541.git'])
+	
+	baseDirectory = os.getcwd()
+	os.chdir('open62541')
+	
+	print('git checkout 7b273f046a0affc61e83837f8df3b6377a835512')
+	subprocess.call(['git', 'checkout', '7b273f046a0affc61e83837f8df3b6377a835512'])
+	deleteFolderRecursively('.', 'build')
+	os.mkdir('build')
+	os.chdir('build')
+	
+	if platform.system() == "Windows":
+		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../ -G "Visual Studio 12 2013 Win64"')
+		subprocess.call('cmake -DUA_ENABLE_AMALGAMATION=ON ../ -G "Visual Studio 12 2013 Win64"', shell=True)
+
+		# TODO: check to see if cmake can locate and invoke the vcvarsall.bat for the Vis Studio version provided with the -G option
+		print('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=Release')
+		subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=Release', shell=True)
+	elif platform.system() == "Linux":
+		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../')
+		subprocess.call(['cmake', '-DUA_ENABLE_AMALGAMATION=ON', '../'])
+		print('make')
+		subprocess.call(['make'], stdout=out)
+		
+	os.chdir(baseDirectory)
+	
+	deleteFileRecursively('include', 'open62541.h')
+	deleteFileRecursively('src', 'open62541.c')
+	copyfile('open62541/build/open62541.h', 'include/open62541.h')
+	copyfile('open62541/build/open62541.c', 'src/open62541.c')
+	
+main()

--- a/prepare.py
+++ b/prepare.py
@@ -15,63 +15,55 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 '''
 
 import os
+import stat
 import sys
 import shutil
 import platform
 import subprocess
-from shutil import copyfile
+	
+baseDir = os.getcwd()
+open6Dir = os.path.join(baseDir, 'open62541')
+open6BuildDir = os.path.join(open6Dir, 'build')
+CMD_generateProjForVisStu12 = 'cmake -DUA_ENABLE_AMALGAMATION=ON {0} -G "Visual Studio 12 Win64"'.format(open6Dir)
+CMD_loadVisStu12Env = '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64'
+CMD_buildProjWithVisStu12 = 'msbuild {0} /clp:ErrorsOnly /property:Platform=x64;Configuration=Release'.format(os.path.join(open6Dir, 'ALL_BUILD.vcxproj'))
 
-def deleteFolderRecursively( topdir, target ):
-	for dirpath, dirnames, files in os.walk(topdir):
-		for name in dirnames:
-			if name == target:
-				try:
-					shutil.rmtree(os.path.join(dirpath, name))
-				except OSError:
-					pass
-	return;
-def deleteFileRecursively( topdir, target ):
-	for dirpath, dirnames, files in os.walk(topdir):
-		for name in files:
-			if name == target:
-				try:
-					os.remove(os.path.join(dirpath, name))					
-				except OSError:
-					pass
-	return;
-	
+def remove_readonly(func, path, _):
+	print('clearing read only flag for directory [{0}]'.format(path))
+	os.chmod(path, stat.S_IWRITE)
+	func(path)
+
 def main():
-	deleteFolderRecursively('.', 'open62541')
+	if(os.path.exists(open6Dir)):
+		print('deleting existing open6 directory [{0}]'.format(open6Dir))
+		shutil.rmtree(open6Dir, onerror=remove_readonly)
+		print('does directory exist now? [{0}]'.format(os.path.exists(open6Dir)))
+
 	print('git clone https://github.com/open62541/open62541.git')
-	subprocess.call(['git', 'clone', 'https://github.com/open62541/open62541.git'])
+	subprocess.check_call(['git', 'clone', 'https://github.com/open62541/open62541.git'])
 	
-	baseDirectory = os.getcwd()
-	os.chdir('open62541')
+	os.chdir(open6Dir)
 	
 	print('git checkout 7b273f046a0affc61e83837f8df3b6377a835512')
-	subprocess.call(['git', 'checkout', '7b273f046a0affc61e83837f8df3b6377a835512'])
-	deleteFolderRecursively('.', 'build')
-	os.mkdir('build')
-	os.chdir('build')
+	subprocess.check_call(['git', 'checkout', '7b273f046a0affc61e83837f8df3b6377a835512'])
+
+	shutil.rmtree(open6BuildDir, ignore_errors=True)
+	os.mkdir(open6BuildDir)
+	os.chdir(open6BuildDir)
 	
 	if platform.system() == "Windows":
-		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../ -G "Visual Studio 12 2013 Win64"')
-		subprocess.call('cmake -DUA_ENABLE_AMALGAMATION=ON ../ -G "Visual Studio 12 2013 Win64"', shell=True)
+		print('generating Visual Studio 12 project, command: {0}', format(CMD_generateProjForVisStu12))
+		subprocess.check_call(CMD_generateProjForVisStu12, shell=True)
 
-		# TODO: check to see if cmake can locate and invoke the vcvarsall.bat for the Vis Studio version provided with the -G option
-		print('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=Release')
-		subprocess.call('"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64 && msbuild ALL_BUILD.vcxproj /clp:ErrorsOnly /property:Platform=x64;Configuration=Release', shell=True)
+		print('loading Visual Studio 12 environment and building project (in same shell to retain environment vars), command: {0} && {1}'.format(CMD_loadVisStu12Env, CMD_buildProjWithVisStu12))
+		subprocess.check_call('{0} && {1}'.format(CMD_loadVisStu12Env, CMD_buildProjWithVisStu12), shell=True)
 	elif platform.system() == "Linux":
 		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../')
-		subprocess.call(['cmake', '-DUA_ENABLE_AMALGAMATION=ON', '../'])
+		subprocess.check_call(['cmake', '-DUA_ENABLE_AMALGAMATION=ON', '../'])
 		print('make')
-		subprocess.call(['make'], stdout=out)
+		subprocess.check_call(['make'], stdout=out)
 		
-	os.chdir(baseDirectory)
-	
-	deleteFileRecursively('include', 'open62541.h')
-	deleteFileRecursively('src', 'open62541.c')
-	copyfile('open62541/build/open62541.h', 'include/open62541.h')
-	copyfile('open62541/build/open62541.c', 'src/open62541.c')
+	shutil.copyfile(os.path.join(open6BuildDir, 'open62541.h'), os.path.join(baseDir, 'include', 'open62541.h'))
+	shutil.copyfile(os.path.join(open6BuildDir, 'open62541.c'), os.path.join(baseDir, 'src', 'open62541.c'))
 	
 main()

--- a/prepare.py
+++ b/prepare.py
@@ -26,7 +26,7 @@ open6Dir = os.path.join(baseDir, 'open62541')
 open6BuildDir = os.path.join(open6Dir, 'build')
 CMD_generateProjForVisStu12 = 'cmake -DUA_ENABLE_AMALGAMATION=ON {0} -G "Visual Studio 12 Win64"'.format(open6Dir)
 CMD_loadVisStu12Env = '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64'
-CMD_buildProjWithVisStu12 = 'msbuild {0} /clp:ErrorsOnly /property:Platform=x64;Configuration=Release'.format(os.path.join(open6Dir, 'ALL_BUILD.vcxproj'))
+CMD_buildProjWithVisStu12 = 'msbuild {0} /clp:ErrorsOnly /property:Platform=x64;Configuration=Release'.format(os.path.join(open6BuildDir, 'ALL_BUILD.vcxproj'))
 
 def remove_readonly(func, path, _):
 	print('clearing read only flag for directory [{0}]'.format(path))

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <opcua_basedatavariabletype.h>
 #include <ASUtils.h>
+#include <stdexcept>
 
 NodeManagerBase::NodeManagerBase( const char* uri, bool sth, int hashtablesize ):
   m_server(0),

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -197,6 +197,7 @@ UaStatus NodeManagerBase::addNodeAndReference(
 
 void NodeManagerBase::linkServer( UA_Server* server )
 {
+	m_server = server;
 	const int nsIndex = UA_Server_addNamespace( m_server, m_nameSpaceUri.c_str() );
 	if (nsIndex != 2)
 		throw std::logic_error("UA_Server_addNamespace: namespace added to nsindex different than 2. ");

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -26,6 +26,13 @@
 #include <opcua_basedatavariabletype.h>
 #include <ASUtils.h>
 
+NodeManagerBase::NodeManagerBase( const char* uri, bool sth, int hashtablesize ):
+  m_server(0),
+  m_nameSpaceUri(uri)
+{
+
+}
+
 NodeManagerBase::~NodeManagerBase()
 {
 
@@ -187,4 +194,9 @@ UaStatus NodeManagerBase::addNodeAndReference(
 }
 
 
-
+void NodeManagerBase::linkServer( UA_Server* server )
+{
+	const int nsIndex = UA_Server_addNamespace( m_server, m_nameSpaceUri.c_str() );
+	if (nsIndex != 2)
+		throw std::logic_error("UA_Server_addNamespace: namespace added to nsindex different than 2. ");
+}

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -69,9 +69,15 @@ static UA_StatusCode unifiedRead(void *handle, const UA_NodeId nodeid, UA_Boolea
 {
     // we expect that the handle points to an object of subclass of BaseDataVariableType
     OpcUa::BaseDataVariableType *variable = static_cast<OpcUa::BaseDataVariableType*>(handle);
-    std::cout << "static cast is " << variable << std::endl;
-    std::cout << "read request comes from " << variable->nodeId().toString().toUtf8() << std::endl;
-    UA_DataValue_copy( variable->valueImpl(), dataValue );
+
+    UaDataValue aCopy( variable->value(0) ); // internally cloned so we can do anything with this object
+    UA_DataValue_copy( aCopy.impl(), dataValue );
+
+    // Piotr: I think that this version of open6 is leaking, try to use this code and you will see:
+    // dataValue->hasValue = true;
+    // double v = rand();
+    // UA_Variant_setScalarCopy(&dataValue->value, &v, &UA_TYPES[UA_TYPES_DOUBLE]);
+    
     return UA_STATUSCODE_GOOD;
 }
 


### PR DESCRIPTION
This fix addresses previous problem: race condition while UA_DataValue object is passed between user's thread (in quasar server) and open62541 network thread.

Studying couple of possibilities I decided to propose a solution which is composed of clone() method in UaDataValue(). A possible race condition is avoided using busy-waiting user-space mutex based on top of atomic boolean with atomic test_and_set(), with memory ordering (for reference, see i.e. http://en.cppreference.com/w/cpp/atomic/atomic_flag)

I believe that this is the best we can get at the moment. A possible deficit of this solution is that it requires a bit newer compiler than gcc 4.4.7 (from SLC6), however with gcc4.8.2 (from devtoolset-2 in SLC6) it works perfectly well and either way we all move to CC7 in 2 months.

Additional observation: I think that current version of open62541 is a bit leaking and I've done my best to verify that the leak doesn't come from us. I.e. see nodemanagerbase.cpp, unifiedRead() function.
