### PR TITLE
Fix for windows compatibility

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -26,7 +26,7 @@ open6Dir = os.path.join(baseDir, 'open62541')
 open6BuildDir = os.path.join(open6Dir, 'build')
 CMD_generateProjForVisStu12 = 'cmake -DUA_ENABLE_AMALGAMATION=ON {0} -G "Visual Studio 12 Win64"'.format(open6Dir)
 CMD_loadVisStu12Env = '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64'
-CMD_buildProjWithVisStu12 = 'msbuild {0} /clp:ErrorsOnly /property:Platform=x64;Configuration=Release'.format(os.path.join(open6BuildDir, 'ALL_BUILD.vcxproj'))
+CMD_buildProjWithVisStu12 = 'msbuild {0} /clp:ErrorsOnly /property:Platform=x64;Configuration=Release;Debug'.format(os.path.join(open6BuildDir, 'ALL_BUILD.vcxproj'))
 
 def remove_readonly(func, path, _):
 	print('clearing read only flag for directory [{0}]'.format(path))
@@ -57,6 +57,9 @@ def main():
 
 		print('loading Visual Studio 12 environment and building project (in same shell to retain environment vars), command: {0} && {1}'.format(CMD_loadVisStu12Env, CMD_buildProjWithVisStu12))
 		subprocess.check_call('{0} && {1}'.format(CMD_loadVisStu12Env, CMD_buildProjWithVisStu12), shell=True)
+
+		print('building open6 library')
+		subprocess.check_call(CMD_buildProjWithVisStu12)
 	elif platform.system() == "Linux":
 		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../')
 		subprocess.check_call(['cmake', '-DUA_ENABLE_AMALGAMATION=ON', '../'])

--- a/prepare.py
+++ b/prepare.py
@@ -26,7 +26,12 @@ open6Dir = os.path.join(baseDir, 'open62541')
 open6BuildDir = os.path.join(open6Dir, 'build')
 CMD_generateProjForVisStu12 = 'cmake -DUA_ENABLE_AMALGAMATION=ON {0} -G "Visual Studio 12 Win64"'.format(open6Dir)
 CMD_loadVisStu12Env = '"C:\\Program Files (x86)\\Microsoft Visual Studio 12.0\\VC\\vcvarsall.bat" amd64'
-CMD_buildProjWithVisStu12 = 'msbuild {0} /clp:ErrorsOnly /property:Platform=x64;Configuration=Release;Debug'.format(os.path.join(open6BuildDir, 'ALL_BUILD.vcxproj'))
+
+def generateVisualStudioBuildCommand(buildType):
+	print 'generating visual studio build command string for build type [{0}]'.format(buildType)
+	result = 'msbuild {0} /clp:ErrorsOnly /verbosity:detailed /property:Platform=x64 /property:Configuration="{1}"'.format(os.path.join(open6BuildDir, 'ALL_BUILD.vcxproj'), buildType)
+	print 'generated msbuild command: {0}'.format(result)
+	return result
 
 def remove_readonly(func, path, _):
 	print('clearing read only flag for directory [{0}]'.format(path))
@@ -55,11 +60,9 @@ def main():
 		print('generating Visual Studio 12 project, command: {0}', format(CMD_generateProjForVisStu12))
 		subprocess.check_call(CMD_generateProjForVisStu12, shell=True)
 
-		print('loading Visual Studio 12 environment and building project (in same shell to retain environment vars), command: {0} && {1}'.format(CMD_loadVisStu12Env, CMD_buildProjWithVisStu12))
-		subprocess.check_call('{0} && {1}'.format(CMD_loadVisStu12Env, CMD_buildProjWithVisStu12), shell=True)
+		print('loading Visual Studio 12 environment and building project (in same shell to retain environment vars)')
+		subprocess.check_call('{0} && {1} && {2}'.format(CMD_loadVisStu12Env, generateVisualStudioBuildCommand('Release'), generateVisualStudioBuildCommand('Debug')), shell=True)
 
-		print('building open6 library')
-		subprocess.check_call(CMD_buildProjWithVisStu12)
 	elif platform.system() == "Linux":
 		print('cmake -DUA_ENABLE_AMALGAMATION=ON ../')
 		subprocess.check_call(['cmake', '-DUA_ENABLE_AMALGAMATION=ON', '../'])

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -37,7 +37,7 @@ NodeManagerBase::~NodeManagerBase()
 {
 
 
-    std::cout << __PRETTY_FUNCTION__ << std::endl;
+    std::cout << __FUNCTION__ << std::endl;
     std::cout << "m_listNodes.size=" << m_listNodes.size() << std::endl;
     while (!m_listNodes.empty())
     {
@@ -116,7 +116,7 @@ UaStatus NodeManagerBase::addNodeAndReference(
     const UaNodeId& refType)
 {
 	std::cout << __FILE__ << " " << __LINE__ << std::endl;
-   // std::cout << __PRETTY_FUNCTION__ << "from.id=" << from.toString().toUtf8() << " to.id=" << to->nodeId().toString().toUtf8() <<  std::endl;
+   // std::cout << __FUNCTION__ << "from.id=" << from.toString().toUtf8() << " to.id=" << to->nodeId().toString().toUtf8() <<  std::endl;
     // std::cout << "ref=" << refType.toString().toUtf8() << endl;
     UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8().c_str());
 	

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -150,9 +150,9 @@ UaString UaDateTime::toString() const
 }
 
 UaDataValue::UaDataValue( const UaVariant& variant, OpcUa_StatusCode statusCode, const UaDateTime& serverTime, const UaDateTime& sourceTime ):
-    m_lock( ATOMIC_FLAG_INIT )
-
+    m_lock()
 {
+	m_lock.clear();
     m_impl = UA_DataValue_new ();
     if (!m_impl)
         throw std::runtime_error( "UA_DataValue_new returned 0" );
@@ -167,8 +167,9 @@ UaDataValue::UaDataValue( const UaVariant& variant, OpcUa_StatusCode statusCode,
 }
 
 UaDataValue::UaDataValue( const UaDataValue& other ):
-    m_lock( ATOMIC_FLAG_INIT )
+    m_lock()
 {
+	m_lock.clear();
     m_impl = UA_DataValue_new ();
     // LOG(Log::INF) << "allocated new UA_DataValue @ " <<  m_impl;  
     UA_DataValue_copy( other.m_impl, m_impl );

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -53,42 +53,42 @@ void UaVariant::destroyOpen62541Variant(UA_Variant* open62541Variant)
 UaVariant::UaVariant ()
 :m_impl(createAndCheckOpen62541Variant())
 {
-    LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 UaVariant::UaVariant( OpcUa_UInt32 v )
 :m_impl(createAndCheckOpen62541Variant())
 {
     setUInt32( v );
-    LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 UaVariant::UaVariant( OpcUa_Int32 v )
 :m_impl(createAndCheckOpen62541Variant())
 {
     setInt32( v );
-    LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 UaVariant::UaVariant( const UaString& v )
 :m_impl(createAndCheckOpen62541Variant())
 {
     setString( v );
-    LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 UaVariant::UaVariant( OpcUa_Float v )
 :m_impl(createAndCheckOpen62541Variant())
 {
 	setFloat(v);
-	LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+	LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 UaVariant::UaVariant( OpcUa_Boolean v )
 :m_impl(createAndCheckOpen62541Variant())
 {
 	setBool(v);
-	LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+	LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 UaVariant::UaVariant( const UaVariant& other)
@@ -97,7 +97,7 @@ UaVariant::UaVariant( const UaVariant& other)
     const UA_StatusCode status = UA_Variant_copy( other.m_impl, this->m_impl );
     if (status != UA_STATUSCODE_GOOD)
     	throw std::runtime_error("UA_Variant_copy failed 0x"+Utils::toHexString(status) );
-    LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 
@@ -110,7 +110,7 @@ void UaVariant::operator= (const UaVariant &other)
     if (status != UA_STATUSCODE_GOOD)
         throw std::runtime_error("UA_Variant_copy failed 0x"+Utils::toHexString(status) );
 
-    LOG(Log::TRC) << __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
 bool UaVariant::operator==(const UaVariant& other) const
@@ -138,7 +138,7 @@ UaVariant::UaVariant( const UA_Variant& other )
 
 UaVariant::~UaVariant()
 {
-    LOG(Log::TRC) <<"+"<< __PRETTY_FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
+    LOG(Log::TRC) <<"+"<< __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
     destroyOpen62541Variant(m_impl);
     m_impl = 0;
 }
@@ -312,13 +312,13 @@ UaStatus UaVariant::toSimpleType( const UA_DataType* dataType, T* out ) const
     //TODO: in principle it should be possible to convert i.e. Int16->Int32, or Byte->Int16, or so... but this is not supported yet
     if (!m_impl || !m_impl->data)
     {
-    	LOG(Log::DBG) << __PRETTY_FUNCTION__ << " conversion failed, variant is null";
+    	LOG(Log::DBG) << __FUNCTION__ << " conversion failed, variant is null";
         return OpcUa_Bad;
     }
 
     if (dataType != m_impl->type)
     {
-    	LOG(Log::DBG) << __PRETTY_FUNCTION__ << " conversion failed, target type ["<<dataType<<"] does not match variant type ["<<m_impl->type<<"]";
+    	LOG(Log::DBG) << __FUNCTION__ << " conversion failed, target type ["<<dataType<<"] does not match variant type ["<<m_impl->type<<"]";
         return OpcUa_Bad;  // Incompatible data type
     }
 


### PR DESCRIPTION
Two code changes
1. __PRETTY_FUNCTION__ is not known to MSVC; changed to __FUNCTION__
2. std::atomic_flag(ATOMIC_FLAG_INIT), apparently references a deleted function in MSVC. Here's [MS docs on their implementation of std::atomic_flag](https://msdn.microsoft.com/en-us/library/hh874636.aspx) and [here's a stackoverflow question/answer](https://stackoverflow.com/questions/28339054/simple-spinlock-with-atomic-does-not-compile) looking like the same problem.