### PR TITLE
Freed open62541-compat from Utils dependency of quasar

### DIFF
--- a/include/statuscode.h
+++ b/include/statuscode.h
@@ -47,6 +47,7 @@
 #define OpcUa_UncertainInitialValue UA_STATUSCODE_UNCERTAININITIALVALUE
 #define OpcUa_BadUnexpectedError UA_STATUSCODE_BADUNEXPECTEDERROR
 #define OpcUa_BadParentNodeIdInvalid UA_STATUSCODE_BADPARENTNODEIDINVALID
+#define OpcUa_BadServerNotConnected UA_STATUSCODE_BADSERVERNOTCONNECTED
 
 typedef OpcUa_UInt32 OpcUa_StatusCode;
 

--- a/include/statuscode.h
+++ b/include/statuscode.h
@@ -53,7 +53,7 @@ typedef OpcUa_UInt32 OpcUa_StatusCode;
 class UaStatus
 {
 public:
-    UaStatus (int s): m_status(s) {} // from status code
+    UaStatus (OpcUa_StatusCode s): m_status(s) {} // from status code
 UaStatus(): m_status(0x66666) {} // uninitialized
     bool isGood() const { return m_status == UA_STATUSCODE_GOOD; }
     bool isNotGood() const { return !isGood(); }

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -23,9 +23,9 @@
 #include <iostream>
 #include <sstream>
 #include <bitset>
-#include <Utils.h>
 #include <boost/format.hpp>
 #include <boost/date_time.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <open62541_compat_common.h>
 
@@ -274,12 +274,12 @@ UaString UaNodeId::toString() const
 {
     if (identifierType() == IdentifierType::OpcUa_IdentifierType_String)
     {
-        std::string s = "(ns="+Utils::toString(namespaceIndex())+","+UaString(identifierString()).toUtf8()+")";
+        std::string s = "(ns="+boost::lexical_cast<std::string>(namespaceIndex())+","+UaString(identifierString()).toUtf8()+")";
         return UaString(s.c_str());
     }
     else if (identifierType() == IdentifierType::OpcUa_IdentifierType_Numeric)
     {
-        std::string s = "(ns="+Utils::toString(namespaceIndex())+","+Utils::toString(identifierNumeric())+")";
+        std::string s = "(ns="+boost::lexical_cast<std::string>(namespaceIndex())+","+boost::lexical_cast<std::string>(identifierNumeric())+")";
         return UaString(s.c_str());
     }
     return "non-string-id";

--- a/src/statuscode.cpp
+++ b/src/statuscode.cpp
@@ -21,7 +21,11 @@ UaString UaStatus::toString() const
 {
     switch (m_status)
     {
+        case OpcUa_Good: return "Good";
         case OpcUa_BadParentNodeIdInvalid: return "BadParentNodeIdInvalid";
+        case OpcUa_BadDataEncodingInvalid: return "BadDataEncodingInvalid";
+        case OpcUa_BadServerNotConnected: return "BadServerNotConnected";
+        case OpcUa_BadOutOfRange: return "BadOutOfRange";
         default: return ("statuscode=0x"+toHexString(m_status)+" --missing-description--implement-me-in-statuscode.cpp--").c_str();
     }
 }

--- a/src/statuscode.cpp
+++ b/src/statuscode.cpp
@@ -6,16 +6,23 @@
  */
 
 #include <statuscode.h>
-#include <Utils.h>
+#include <sstream>
 
-#include <boost/lexical_cast.hpp>
+template<typename T>
+static std::string toHexString (const T t)
+{
+        std::ostringstream oss;
+        oss << std::hex << (unsigned long)t << std::dec;
+        return oss.str ();
+}
+
 
 UaString UaStatus::toString() const
 {
     switch (m_status)
     {
         case OpcUa_BadParentNodeIdInvalid: return "BadParentNodeIdInvalid";
-        default: return ("statuscode=0x"+Utils::toHexString(m_status)+" --missing-description--implement-me--").c_str();
+        default: return ("statuscode=0x"+toHexString(m_status)+" --missing-description--implement-me-in-statuscode.cpp--").c_str();
     }
 }
 

--- a/src/uastring.cpp
+++ b/src/uastring.cpp
@@ -21,7 +21,6 @@
 
 #include <open62541_compat.h>
 #include <iostream>
-#include <Utils.h>
 
 #include <open62541_compat_common.h>
 

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <sstream>
 #include <bitset>
-#include <Utils.h>
 #include <boost/format.hpp>
 #include <boost/date_time.hpp>
 
@@ -115,9 +114,9 @@ UaVariant::UaVariant( OpcUa_Boolean v )
 UaVariant::UaVariant( const UaVariant& other)
 :m_impl(createAndCheckOpen62541Variant())
 {
-    const UA_StatusCode status = UA_Variant_copy( other.m_impl, this->m_impl );
-    if (status != UA_STATUSCODE_GOOD)
-    	throw std::runtime_error("UA_Variant_copy failed 0x"+Utils::toHexString(status) );
+    const UaStatus status = UA_Variant_copy( other.m_impl, this->m_impl );
+    if (! status.isGood())
+      throw std::runtime_error(std::string("UA_Variant_copy failed:") + status.toString().toUtf8() );
     LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
@@ -127,9 +126,9 @@ void UaVariant::operator= (const UaVariant &other)
 	destroyOpen62541Variant(m_impl);
     m_impl = createAndCheckOpen62541Variant();
     
-    const UA_StatusCode status = UA_Variant_copy( other.m_impl, this->m_impl );
-    if (status != UA_STATUSCODE_GOOD)
-        throw std::runtime_error("UA_Variant_copy failed 0x"+Utils::toHexString(status) );
+    const UaStatus status = UA_Variant_copy( other.m_impl, this->m_impl );
+    if (! status.isGood())
+        throw std::runtime_error(std::string("UA_Variant_copy failed:") + status.toString().toUtf8() );
 
     LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
@@ -190,9 +189,9 @@ void UaVariant::reuseOrRealloc( const UA_DataType* dataType, void* newValue )
         /* Data type different - have to realloc */
         UA_Variant_deleteMembers( m_impl );
         // TODO throw when failed
-        UA_StatusCode status = UA_Variant_setScalarCopy( m_impl, newValue, dataType);
-        if (status != UA_STATUSCODE_GOOD)
-            throw std::runtime_error("UA_Variant_setScalarCopy failed:"+Utils::toHexString(status));
+        UaStatus status = UA_Variant_setScalarCopy( m_impl, newValue, dataType);
+        if (! status.isGood())
+	  throw std::runtime_error(std::string("UA_Variant_setScalarCopy failed:")+status.toString().toUtf8());
     }
 }
 


### PR DESCRIPTION
open62541-compat relied on a header file from Quasar, namely Utils.h, for some handy functions for string conversions. While not a problem for Quasar, it was inconvenient for non-Quasar projects using open62541-compat.

This fix removes this dependency; in most places by migrating to boost::lexical_cast, in other places by importing toHexString directly from Quasar into the file which needs it.

How I tested it: built Wiener OPC-UA server with open62541-compat from this branch, kept it running for few minutes, manipulated some data, haven't seen any regression. 