### PR TITLE
OPCUA-944 uasession disconnect support

### DIFF
--- a/include/uaclient/uasession.h
+++ b/include/uaclient/uasession.h
@@ -22,7 +22,7 @@
 #ifndef INCLUDE_UACLIENT_UASESSION_H_
 #define INCLUDE_UACLIENT_UASESSION_H_
 
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 #include <opcua_types.h>
 #include <uaclient/uaclientsdk.h>
@@ -94,7 +94,7 @@ public:
 
 private:
     UA_Client     *m_client;
-    boost::mutex  m_accessMutex; // used to make all UaSession's methods synchronized
+    std::mutex    m_accessMutex; // used to make all UaSession's methods synchronized
 };
 
 }

--- a/include/uaclient/uasession.h
+++ b/include/uaclient/uasession.h
@@ -22,6 +22,7 @@
 #ifndef INCLUDE_UACLIENT_UASESSION_H_
 #define INCLUDE_UACLIENT_UASESSION_H_
 
+#include <boost/thread/mutex.hpp>
 
 #include <opcua_types.h>
 #include <uaclient/uaclientsdk.h>
@@ -86,8 +87,14 @@ public:
             UaStatusCodeArray &     results,
             UaDiagnosticInfos &     diagnosticInfos );
 
+    UaStatus disconnect(
+            ServiceSettings &       serviceSettings,
+            OpcUa_Boolean           deleteSubscriptions
+        );
+
 private:
-    UA_Client *m_client;
+    UA_Client     *m_client;
+    boost::mutex  m_accessMutex; // used to make all UaSession's methods synchronized
 };
 
 }

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -22,7 +22,6 @@
 #include <stdexcept>
 
 #include <boost/lexical_cast.hpp>
-#include <boost/thread/lock_guard.hpp>
 
 #include <open62541.h>
 #include <open62541_compat_common.h>
@@ -57,7 +56,7 @@ UaStatus UaSession::connect(
         const SessionSecurityInfo&     securityInfo,
         UaSessionCallback*             callback)
 {
-    boost::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
+    std::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
 
     if (m_client)
     {
@@ -86,7 +85,7 @@ UaStatus UaSession::disconnect(
         OpcUa_Boolean           deleteSubscriptions
     )
 {
-    boost::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
+    std::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
     if (! m_client)
     {
         LOG(Log::WRN) << "Can't disconnect because not connected.";
@@ -118,7 +117,7 @@ UaStatus UaSession::read(
             UaDataValues &              values,
             UaDiagnosticInfos &         diagnosticInfos  )
 {
-    boost::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
+    std::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
     if (nodesToRead.size() != 1)
     {
 
@@ -203,7 +202,7 @@ UaStatus UaSession::write(
         UaStatusCodeArray &     results,
         UaDiagnosticInfos &     diagnosticInfos )
 {
-    boost::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
+    std::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
     if (nodesToWrite.size() != 1)
     {
         throw std::runtime_error("UaSession::write(): So far only single writes are supported, but you requested a write of "


### PR DESCRIPTION
(1) make sure that deleting UaSession will disconnect, if connected
(2) add disconnect method to UaSession()
(3) mutex all calls

tested with the sample client generated for SCA OPC-UA