### PR TITLE
OPCUA-1020 client side methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,11 +113,11 @@ else()
   #
   # Resolve LogIt library
   #
-  set(LOGIT_EXT_LIB_DIR "UNINIALIZED" CACHE PATH "Path to the directory containing the LogIt shared/static library binary file. Use absolute path, or relative to [${PROJECT_SOURCE_DIR}/]")
+  set(LOGIT_EXT_LIB_DIR "UNINIALIZED" CACHE PATH "Path to the directory containing the LogIt shared/static library binary file. Use absolute path, or relative to [${PROJECT_BINARY_DIR}/]")
   message(STATUS "Using LogIt build option [${LOGIT_BUILD_OPTION}]")
   if("${LOGIT_BUILD_OPTION}" STREQUAL "LOGIT_AS_INT_SRC")
   	clone_LogIt()
-    add_subdirectory( ${PROJECT_SOURCE_DIR}/LogIt )
+    add_subdirectory( ${PROJECT_BINARY_DIR}/LogIt )
     message(STATUS "LogIt added as compiled object code from sub-directory LogIt")
     add_library( open62541-compat ${OPEN62541_COMPAT_LIB_FORMAT} ${SRCS} $<TARGET_OBJECTS:LogIt>)
   else()
@@ -138,9 +138,9 @@ else()
   #
   # Resolve LogIt include
   #
-  set(LOGIT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/LogIt/include CACHE PATH "Path to LogIt include directory. If building with LogIt as external shared/static library this must be specified using -DLOGIT_INCLUDE_DIR=path. Path can be absolute or relative to [${PROJECT_SOURCE_DIR}/]")
+  set(LOGIT_INCLUDE_DIR ${PROJECT_BINARY_DIR}/LogIt/include CACHE PATH "Path to LogIt include directory. If building with LogIt as external shared/static library this must be specified using -DLOGIT_INCLUDE_DIR=path. Path can be absolute or relative to [${PROJECT_BINARY_DIR}/]")
   if( NOT EXISTS ${LOGIT_INCLUDE_DIR} )
-    message(FATAL_ERROR "Cannot build with LogIt. No LogIt include directory found at [${LOGIT_INCLUDE_DIR}]. If building with LogIt as external shared/static library this must be specified using -DLOGIT_INCLUDE_DIR=path. Path can be absolute or relative to [${PROJECT_SOURCE_DIR}/]")
+    message(FATAL_ERROR "Cannot build with LogIt. No LogIt include directory found at [${LOGIT_INCLUDE_DIR}]. If building with LogIt as external shared/static library this must be specified using -DLOGIT_INCLUDE_DIR=path. Path can be absolute or relative to [${PROJECT_BINARY_DIR}/]")
   endif()
   message(STATUS "Using LogIt include directory [${LOGIT_INCLUDE_DIR}]")
   include_directories( ${LOGIT_INCLUDE_DIR} )

--- a/include/uaclient/uaclientsdk.h
+++ b/include/uaclient/uaclientsdk.h
@@ -29,6 +29,4 @@
 #include <uabytestring.h>
 #include <uaclient/uasession.h>
 
-
-
 #endif /* OPEN62541_COMPAT_INCLUDE_UACLIENT_UACLIENTSDK_H_ */

--- a/include/uaclient/uasession.h
+++ b/include/uaclient/uasession.h
@@ -46,6 +46,24 @@ struct SessionConnectInfo
     UaString    sProductUri;
 };
 
+struct CallIn
+{
+    CallIn(): objectId(0, 0), methodId(0,0) {}
+
+    UaNodeId         objectId;
+    UaNodeId         methodId;
+    UaVariantArray   inputArguments;
+};
+
+struct CallOut
+{
+    UaStatus          callResult;
+    UaStatusCodeArray inputArgumentResults;
+    UaDiagnosticInfos inputArgumentDiagnosticInfos;
+    UaVariantArray    outputArguments;
+
+};
+
 namespace UaClient
 {
 
@@ -87,10 +105,17 @@ public:
             UaStatusCodeArray &     results,
             UaDiagnosticInfos &     diagnosticInfos );
 
+    UaStatus call(
+            ServiceSettings &       serviceSettings,
+            const CallIn &          callRequest,
+            CallOut &               callResponse
+        );
+
     UaStatus disconnect(
             ServiceSettings &       serviceSettings,
             OpcUa_Boolean           deleteSubscriptions
         );
+
 
 private:
     UA_Client     *m_client;

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -231,11 +231,16 @@ UaStatus UaSession::write(
     UA_WriteResponse writeResponse = UA_Client_Service_write(m_client, writeRequest);
     UA_Array_delete(writeRequest.nodesToWrite, writeRequest.nodesToWriteSize, &UA_TYPES[UA_TYPES_WRITEVALUE]);
 
-    results.create( nodesToWrite.size() );
-    for (size_t i=0; i<nodesToWrite.size(); ++i)
+    if (UaStatus(writeResponse.responseHeader.serviceResult).isGood())
     {
-        results[i] = writeResponse.results[i];
+        results.create( writeResponse.resultsSize );
+        for (size_t i=0; i<writeResponse.resultsSize; ++i)
+        {
+            results[i] = writeResponse.results[i];
+        }
     }
+    else
+        results.create(0); // assume there are no results when the service call failed
 
     UA_Array_delete(writeResponse.results, writeResponse.resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
 

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -243,4 +243,78 @@ UaStatus UaSession::write(
 }
 
 
+/* What's not implemented:
+ * - diagnosticInfos
+ */
+UaStatus UaSession::call(
+        ServiceSettings &       serviceSettings,
+        const CallIn &          callIn,
+        CallOut &               callOut
+    )
+{
+    std::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
+
+    UA_CallMethodRequest methodCallRequest;
+    UA_CallMethodRequest_init(&methodCallRequest);
+    methodCallRequest.methodId = callIn.methodId.impl();
+    methodCallRequest.objectId = callIn.objectId.impl();
+    methodCallRequest.inputArgumentsSize = callIn.inputArguments.size();
+    methodCallRequest.inputArguments = (UA_Variant*)UA_Array_new( callIn.inputArguments.size(), &UA_TYPES[UA_TYPES_VARIANT] );
+
+    if (!methodCallRequest.inputArguments)
+        throw std::runtime_error("UA_Array_new failed to allocate an array");
+
+    bool anyArgumentFailed = false;
+    for (unsigned int i=0; i<callIn.inputArguments.size(); ++i)
+    {
+        UA_Variant_init(&methodCallRequest.inputArguments[i]);
+        UaStatus status = UA_Variant_copy(callIn.inputArguments[i].impl(), &methodCallRequest.inputArguments[i] );
+        if (!status.isGood())
+        {
+            LOG(Log::ERR) << "UA_Variant_copy said: " << status.toString().toUtf8();
+            anyArgumentFailed = true;
+        }
+    }
+    if (anyArgumentFailed)
+    { // free all, no point in continuing
+        UA_Array_delete(methodCallRequest.inputArguments, callIn.inputArguments.size(), &UA_TYPES[UA_TYPES_VARIANT]);
+        throw std::runtime_error("Failed to copy arguments through UA_Variant_copy, potentially memory issue.");
+    }
+
+    UA_CallRequest callRequest;
+    UA_CallRequest_init( &callRequest);
+
+    callRequest.methodsToCallSize = 1;
+    callRequest.methodsToCall = &methodCallRequest;
+
+    UA_CallResponse callResponse;
+    UA_CallResponse_init(&callResponse);
+    callResponse = UA_Client_Service_call(m_client, callRequest);
+
+    UA_Array_delete(methodCallRequest.inputArguments, callIn.inputArguments.size(), &UA_TYPES[UA_TYPES_VARIANT]);
+
+    callOut.inputArgumentDiagnosticInfos.create(0);
+    callOut.inputArgumentResults.create(0);
+
+    // there should be at least one callResponse result because we called one method
+    if (callResponse.resultsSize != 1)
+        throw std::logic_error("One method called so expected one call response, but instead got: "+boost::lexical_cast<std::string>(callResponse.resultsSize)+", open62541 error?");
+
+    UA_CallMethodResult *result = &callResponse.results[0];
+
+    callOut.outputArguments.create( result->outputArgumentsSize );
+    for (unsigned int i=0; i<result->outputArgumentsSize; ++i)
+    {
+        callOut.outputArguments[i] = result->outputArguments[i];
+    }
+
+    callOut.callResult = callResponse.responseHeader.serviceResult;
+
+    UA_Array_delete( callResponse.results, callResponse.resultsSize, &UA_TYPES[UA_TYPES_CALLMETHODRESULT] );
+
+    return callOut.callResult;
+
+}
+
+
 }


### PR DESCRIPTION
Task driven by FPGA configuration for NSW et al.

It introduces client-side method calling (no relation to open62541-client method support for servers! that is a separate mechanism).

Tested with calling of big ByteString (52MB of size), worked fine, no single warning from valgrind.
Wrong status codes seem well handled.

Aspects not tested: return values passing.