### PR TITLE
Lets control the IO timeout of the calls

### DIFF
--- a/include/uaclient/uasession.h
+++ b/include/uaclient/uasession.h
@@ -44,6 +44,13 @@ struct SessionConnectInfo
     UaString    sApplicationName;
     UaString    sApplicationUri;
     UaString    sProductUri;
+    OpcUa_UInt32  internalServiceCallTimeout;
+    SessionConnectInfo() :
+        sApplicationName("OPC-UA client"),
+        sApplicationUri("OPC-UA client"),
+        sProductUri("OPC-UA client"),
+        internalServiceCallTimeout(5000)
+    {}
 };
 
 namespace UaClient

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -63,7 +63,9 @@ UaStatus UaSession::connect(
         LOG(Log::ERR) << "Connection already exists, can't call connect()";
         return OpcUa_Bad;  // Already connected!
     }
-    m_client = UA_Client_new(UA_ClientConfig_standard);
+    UA_ClientConfig clientConfig = UA_ClientConfig_standard;
+    clientConfig.timeout = connectInfo.internalServiceCallTimeout;
+    m_client = UA_Client_new(clientConfig);
     if (!m_client)
         throw alloc_error();
     UaStatus status = UA_Client_connect(m_client, endpoint.toUtf8().c_str());


### PR DESCRIPTION
A simple but important one which saves you whenever the service call you intend to execute will take longer than the default 5 seconds.