### PR TITLE
Added OpcUa_BadArgumentsMissing

### DIFF
--- a/include/statuscode.h
+++ b/include/statuscode.h
@@ -51,6 +51,7 @@
 #define OpcUa_BadServerNotConnected UA_STATUSCODE_BADSERVERNOTCONNECTED
 #define OpcUa_BadIndexRangeInvalid UA_STATUSCODE_BADINDEXRANGEINVALID
 #define OpcUa_BadIndexRangeNoData UA_STATUSCODE_BADINDEXRANGENODATA
+#define OpcUa_BadArgumentsMissing UA_STATUSCODE_BADARGUMENTSMISSING
 
 typedef OpcUa_UInt32 OpcUa_StatusCode;
 


### PR DESCRIPTION
Simply adds a single status code mapping to the open62541 codes. A one liner.