### PR TITLE
OPCUA-937 improve uasession memory management

### DIFF
--- a/include/managed_uaarray.h
+++ b/include/managed_uaarray.h
@@ -1,0 +1,65 @@
+/*
+ * managed_uaarray.h
+ *
+ *  Created on: 12 Jul 2018
+ *      Author: pnikiel
+ *
+ * The purpose of this class is to provide UA_Array with:
+ * - RAII (e.g. auto-destruction on going out-of-scope)
+ * - without necessity to do void* casting by the programmer
+ */
+
+#ifndef INCLUDE_MANAGED_UAARRAY_H_
+#define INCLUDE_MANAGED_UAARRAY_H_
+
+#include <open62541.h>
+#include <open62541_compat_common.h>
+
+/** T is the type contained in the array */
+
+template<typename T>
+class ManagedUaArray
+{
+public:
+
+    //! This ctr is for constructing an array
+    ManagedUaArray(size_t sz, const UA_DataType* type):
+        m_size(sz),
+        m_dataType(type)
+    {
+        m_array = static_cast<T*> (UA_Array_new(sz, type));
+        if (!m_array)
+        {
+            throw alloc_error();
+        }
+    }
+
+    //! This ctr is for already allocated array (e.g. returned from open62541 service call)
+    ManagedUaArray(size_t sz, const UA_DataType* type, T* array):
+        m_size(sz),
+        m_dataType(type),
+        m_array(array)
+    {}
+
+    virtual ~ManagedUaArray()
+    {
+        UA_Array_delete(m_array, m_size, m_dataType);
+    }
+
+    operator T* ()
+    {
+        return m_array;
+    }
+
+private:
+    const size_t        m_size;
+    const UA_DataType*  m_dataType;
+    T*                  m_array;
+
+
+
+};
+
+
+
+#endif /* INCLUDE_MANAGED_UAARRAY_H_ */

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -213,7 +213,8 @@ UaStatus UaSession::write(
     UA_WriteRequest_init( &writeRequest);
 
     writeRequest.nodesToWriteSize = nodesToWrite.size();
-    writeRequest.nodesToWrite = (UA_WriteValue*) UA_Array_new(nodesToWrite.size(), &UA_TYPES[UA_TYPES_WRITEVALUE]);
+    ManagedUaArray<UA_WriteValue> writeValues (nodesToWrite.size(), &UA_TYPES[UA_TYPES_WRITEVALUE]);
+    writeRequest.nodesToWrite = writeValues;
 
     for (size_t i = 0; i<nodesToWrite.size(); ++i)
     {
@@ -228,7 +229,7 @@ UaStatus UaSession::write(
 
 
     UA_WriteResponse writeResponse = UA_Client_Service_write(m_client, writeRequest);
-    UA_Array_delete(writeRequest.nodesToWrite, writeRequest.nodesToWriteSize, &UA_TYPES[UA_TYPES_WRITEVALUE]);
+    ManagedUaArray<UA_StatusCode> statusCodes( writeResponse.resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE], writeResponse.results );
 
     if (UaStatus(writeResponse.responseHeader.serviceResult).isGood())
     {
@@ -240,8 +241,6 @@ UaStatus UaSession::write(
     }
     else
         results.create(0); // assume there are no results when the service call failed
-
-    UA_Array_delete(writeResponse.results, writeResponse.resultsSize, &UA_TYPES[UA_TYPES_STATUSCODE]);
 
     return writeResponse.responseHeader.serviceResult;
 }

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -28,6 +28,7 @@
 #include <uaclient/uasession.h>
 #include <uadatavalue.h>
 #include <LogIt.h>
+#include <managed_uaarray.h>
 
 namespace UaClientSdk
 {
@@ -106,10 +107,7 @@ UaStatus UaSession::disconnect(
  * What's not implemented:
  * - diagnostic infos (TODO)
  * - taking into account serviceSettings (TODO)
- * - type of timestamps (TODO)
- * - maxAge (TODO)
  *
- * also: this code is highlt non-reentrant because of open62541- TODO: mutex it!
  */
 UaStatus UaSession::read(
             ServiceSettings &           serviceSettings,
@@ -138,7 +136,8 @@ UaStatus UaSession::read(
 
     UA_ReadRequest readRequest;
     UA_ReadRequest_init(&readRequest);
-    readRequest.nodesToRead =  (UA_ReadValueId*) UA_Array_new(1, &UA_TYPES[UA_TYPES_READVALUEID]);
+    ManagedUaArray<UA_ReadValueId> readValueIds (1, &UA_TYPES[UA_TYPES_READVALUEID]);
+    readRequest.nodesToRead = readValueIds;
     readRequest.nodesToReadSize = 1;
     // The following should be safe because enum values are defined with open62541 defines
     readRequest.timestampsToReturn = (UA_TimestampsToReturn)timeStamps;
@@ -150,8 +149,7 @@ UaStatus UaSession::read(
     readRequest.nodesToRead[0].attributeId = nodesToRead[0].AttributeId;
 
     UA_ReadResponse readResponse = UA_Client_Service_read(m_client, readRequest);
-
-    UA_Array_delete(readRequest.nodesToRead, 1, &UA_TYPES[UA_TYPES_READVALUEID]);
+    ManagedUaArray<UA_DataValue> readResponseResults( readResponse.resultsSize, &UA_TYPES[UA_TYPES_DATAVALUE], readResponse.results);
 
     UaStatus serviceStatus = UaStatus(readResponse.responseHeader.serviceResult);
 
@@ -163,7 +161,6 @@ UaStatus UaSession::read(
                     << boost::lexical_cast<std::string>(readRequest.nodesToReadSize)
                     << " and returned size "
                     << boost::lexical_cast<std::string>(readResponse.resultsSize);
-            UA_ReadRequest_deleteMembers(&readRequest);
             return OpcUa_Bad;
         }
         for (size_t i=0; i<nodesToRead.size(); ++i)
@@ -193,7 +190,6 @@ UaStatus UaSession::read(
         }
     }
 
-    UA_Array_delete(readResponse.results, readResponse.resultsSize, &UA_TYPES[UA_TYPES_DATAVALUE]);
 
     return serviceStatus;
 


### PR DESCRIPTION
As per your suggestion in:
https://its.cern.ch/jira/browse/OPCUA-937

Tested with valgrind for both write() and read() for successful and failed(Non-existing node) scenarios.