### PR TITLE
Implemented the check and safe conversion

### DIFF
--- a/include/uabytestring.h
+++ b/include/uabytestring.h
@@ -26,7 +26,7 @@ public:
 
 	~UaByteString ();
 
-	OpcUa_Int32 length() const { return m_impl->length; }
+	OpcUa_Int32 length() const;
 	const OpcUa_Byte* data() const { return m_impl->data; }
 
 	void setByteString (const int len, OpcUa_Byte *Data);

--- a/src/uabytestring.cpp
+++ b/src/uabytestring.cpp
@@ -5,6 +5,8 @@
  *      Author: pnikiel
  */
 
+#include <limits>
+
 #include <uabytestring.h>
 
 #include <open62541_compat_common.h>
@@ -66,4 +68,12 @@ void UaByteString::setByteString (const int len, OpcUa_Byte *data)
 	}
 	m_impl->length = len;
 
+}
+
+OpcUa_Int32 UaByteString::length() const
+{
+    if (m_impl->length > std::numeric_limits<OpcUa_Int32>::max() )
+        throw std::runtime_error("UaByteString::length() open62541 size too big for UASDK API");
+    else
+        return m_impl->length;
 }


### PR DESCRIPTION
https://its.cern.ch/jira/browse/OPCUA-1243

By fixing this, in addition to feeling better, we will remove tenths of warnings that any Windows build with o6-compat generates