### PR TITLE
OPCUA-2036 unify open62541 compat log and throw

### DIFF
--- a/include/open62541_compat.h
+++ b/include/open62541_compat.h
@@ -47,7 +47,11 @@
 #include <opcua_basedatavariabletype.h>
 
 
-
+#define OPEN62541_COMPAT_LOG_AND_THROW(EXCEPTION_TYPE, MSG) \
+    { \
+    LOG(Log::ERR) << MSG; \
+    throw EXCEPTION_TYPE (MSG); \
+    }
 
 
 class IOManager

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -305,7 +305,9 @@ UaStatus NodeManagerBase::addVariableNodeAndReference(
     	return addDataVariableNodeAndReference(parent, cast, refType);
     }
     else
-    	throw std::logic_error("Can't add this variable: do not know what to do! Added variable address is " + to->nodeId().toString().toUtf8());
+    	OPEN62541_COMPAT_LOG_AND_THROW(
+    			std::logic_error,
+				"Can't add this variable: no obvious handler in existing open62541 interface, do not know what to do! Requested variable address is " + to->nodeId().toString().toUtf8());
 }
 
 UaStatus NodeManagerBase::addPropertyNodeAndReference(
@@ -331,7 +333,9 @@ UaStatus NodeManagerBase::addPropertyNodeAndReference(
 					/* nodeContext */ nullptr,
 					/* outNewNodeId */ nullptr);
 	if (!s.isGood())
-		throw std::runtime_error("failed to add property");
+		OPEN62541_COMPAT_LOG_AND_THROW(
+				std::runtime_error,
+				"failed to add property " + to->nodeId().toString().toUtf8() + " because: " + s.toString().toUtf8());
 	return s;
 }
 
@@ -405,7 +409,9 @@ UaStatus NodeManagerBase::addMethodNodeAndReference(
             nullptr);
     if (! s.isGood())
     {
-        throw std::runtime_error("failed to add the method node:"+std::string(s.toString().toUtf8()));
+    	OPEN62541_COMPAT_LOG_AND_THROW(
+    			std::runtime_error,
+				"failed to add the method node:"+std::string(s.toString().toUtf8()));
     }
     m_listNodes.push_back( to );
     parent->addReferencedTarget( to, refType );
@@ -429,7 +435,9 @@ UaStatus NodeManagerBase::addNodeAndReference(
     case OpcUa_NodeClass_Method:
         return addMethodNodeAndReference(parent, to, refType);
     default:
-        throw std::runtime_error("Adding this nodeClass to the address space is not yet implemented by open62541-compat.");
+        OPEN62541_COMPAT_LOG_AND_THROW(
+			std::runtime_error,
+			"Adding this nodeClass to the address space is not yet implemented by open62541-compat.");
     }
 }
 
@@ -451,7 +459,8 @@ void NodeManagerBase::linkServer( UA_Server* server )
     m_server = server;
     const int nsIndex = UA_Server_addNamespace( m_server, m_nameSpaceUri.c_str() );
     if (nsIndex != 2)
-        throw std::logic_error("UA_Server_addNamespace: namespace added to nsindex different than 2. ");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::logic_error,
+    			"UA_Server_addNamespace: namespace added to nsindex different than 2 (it must be 2 for the moment due to simplified compatibility with UA-SDK");
 }
 
 UaStatus NodeManagerBase::afterStartUp()

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -87,6 +87,7 @@ OpcUa_NodeClass safeConvertNodeClassToSdk (UA_NodeClass nc)
 	case UA_NodeClass::UA_NODECLASS_OBJECT: return OpcUa_NodeClass::OpcUa_NodeClass_Object;
 	case UA_NodeClass::UA_NODECLASS_VARIABLE: return OpcUa_NodeClass::OpcUa_NodeClass_Variable;
 	default:
-		throw std::runtime_error("This node class is not implemented: " + std::to_string(nc) + ", improve me!");
+		OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error,
+				"This node class is not implemented: " + std::to_string(nc) + ", improve me!");
 	}
 }

--- a/src/uabytestring.cpp
+++ b/src/uabytestring.cpp
@@ -11,6 +11,7 @@
 #include <statuscode.h>
 
 #include <open62541_compat_common.h>
+#include <open62541_compat.h>
 
 UaByteString::UaByteString ()
 {
@@ -25,7 +26,7 @@ UaByteString::UaByteString( const UA_ByteString& other):
 {
     UaStatus status = UA_ByteString_copy(&other, m_impl);
     if (!status.isGood())
-        throw std::runtime_error("UA_ByteString_copy failed: " + status.toString().toUtf8());
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_ByteString_copy failed: " + status.toString().toUtf8());
 }
 
 UaByteString::UaByteString( const int length, const OpcUa_Byte* data):
@@ -82,7 +83,7 @@ void UaByteString::setByteString (const int len, const OpcUa_Byte *data)
 OpcUa_Int32 UaByteString::length() const
 {
     if (m_impl->length > std::numeric_limits<OpcUa_Int32>::max() )
-        throw std::runtime_error("UaByteString::length() open62541 size too big for UASDK API");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UaByteString::length() open62541 size too big for UASDK API")
     else
         return m_impl->length;
 }
@@ -92,7 +93,7 @@ void UaByteString::copyTo(UaByteString* other) const
     other->release();
     UaStatus status = UA_ByteString_copy(m_impl, other->m_impl);
     if (!status.isGood())
-        throw std::runtime_error("UA_ByteString_copy failed with: " + status.toString().toUtf8());
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_ByteString_copy failed with: " + status.toString().toUtf8());
 }
 
 void UaByteString::release()

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -29,6 +29,7 @@
 #include <uadatavalue.h>
 #include <LogIt.h>
 #include <managed_uaarray.h>
+#include <open62541_compat.h>
 
 namespace UaClientSdk
 {
@@ -126,7 +127,8 @@ UaStatus UaSession::read(
     if (nodesToRead.size() != 1)
     {
 
-        throw std::runtime_error("UaSession::read(): So far only single reads are supported, but you requested a read of "
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error,
+    			"UaSession::read(): So far only single reads are supported, but you requested a read of "
                 +boost::lexical_cast<std::string>(nodesToRead.size())+" items. FIXME!");
         // FIXME:implement this
     }
@@ -134,7 +136,8 @@ UaStatus UaSession::read(
     LOG(Log::TRC) << "UaSession::read( nodesToRead=[" << nodesToRead[0].NodeId.toString().toUtf8() << "] )";
 
     if (nodesToRead.size() != values.size())
-        throw std::runtime_error("Size of provided value holders (is "
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error,
+    			"Size of provided value holders (is "
                 +boost::lexical_cast<std::string>(values.size())
                 +" must match size of provided nodesToRead (is "
                 +boost::lexical_cast<std::string>(nodesToRead.size()));
@@ -209,7 +212,8 @@ UaStatus UaSession::write(
     std::lock_guard<decltype(m_accessMutex)> lock (m_accessMutex);
     if (nodesToWrite.size() != 1)
     {
-        throw std::runtime_error("UaSession::write(): So far only single writes are supported, but you requested a write of "
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error,
+    			"UaSession::write(): So far only single writes are supported, but you requested a write of "
                 +boost::lexical_cast<std::string>(nodesToWrite.size())+" items. FIXME!");
         // FIXME:implement this
     }
@@ -310,7 +314,8 @@ UaStatus UaSession::call(
 
     // there should be at least one callResponse result because we called one method
     if (callResponse.resultsSize != 1)
-        throw std::logic_error("One method called so expected one call response, but instead got: "+boost::lexical_cast<std::string>(callResponse.resultsSize)+", open62541 error?");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::logic_error,
+    			"One method called so expected one call response, but instead got: "+boost::lexical_cast<std::string>(callResponse.resultsSize)+", open62541 error?");
 
     UA_CallMethodResult *result = &callResponse.results[0];
 

--- a/src/uadatavalue.cpp
+++ b/src/uadatavalue.cpp
@@ -13,6 +13,7 @@
 
 #include <LogIt.h>
 #include <uadatavalue.h>
+#include <open62541_compat.h>
 
 UaDataValue::UaDataValue( const UaVariant& variant, OpcUa_StatusCode statusCode, const UaDateTime& serverTime, const UaDateTime& sourceTime ):
 m_lock()
@@ -20,7 +21,9 @@ m_lock()
     m_lock.clear();
     m_impl = UA_DataValue_new ();
     if (!m_impl)
-        throw std::runtime_error( "UA_DataValue_new returned 0" );
+    	OPEN62541_COMPAT_LOG_AND_THROW(
+    			std::runtime_error,
+				"UA_DataValue_new returned null ptr" );
 
     // TODO: duplicate the variant
     UA_Variant_copy( variant.impl(), &m_impl->value );

--- a/src/uadatavariablecache.cpp
+++ b/src/uadatavariablecache.cpp
@@ -5,10 +5,10 @@
  *      Author: pnikiel
  */
 
-
-#include <uadatavariablecache.h>
 #include <stdexcept>
 
+#include <uadatavariablecache.h>
+#include <open62541_compat.h>
 
 
 UaPropertyMethodArgument::UaPropertyMethodArgument  (
@@ -54,7 +54,9 @@ OpcUa_StatusCode UaPropertyMethodArgument::setArgument 	(
 const UA_Argument& UaPropertyMethodArgument::implArgument (unsigned int index) const
 {
 	if (index >= m_numberArguments)
-		throw std::runtime_error("wrong arg");
+		OPEN62541_COMPAT_LOG_AND_THROW(
+				std::out_of_range,
+				"asking for argument past initially declared range");
 	return *m_impl[index];
 }
 

--- a/src/uadatetime.cpp
+++ b/src/uadatetime.cpp
@@ -21,9 +21,11 @@
  */
 
 
-#include <uadatetime.h>
 #include <boost/format.hpp>
 #include <boost/date_time.hpp>
+
+#include <uadatetime.h>
+#include <open62541_compat.h>
 
 UaDateTime::UaDateTime()
 :m_dateTime{0}
@@ -69,7 +71,7 @@ UaDateTime UaDateTime::fromString(const UaString& dateTimeString)
 
                 if(unixEpoch.is_not_a_date_time())
                 {
-                        throw std::runtime_error("Failed to calculate unix epoch, cannot parse any dates from strings.");
+                        OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "Failed to calculate unix epoch, cannot parse any dates from strings.");
                 }
 
                 boost::posix_time::ptime dateTime;
@@ -79,7 +81,7 @@ UaDateTime UaDateTime::fromString(const UaString& dateTimeString)
                 {
                         std::ostringstream err;
                         err << "Failed to convert string ["<<stdDateTimeString<<"] to a date, valid format ["<<timeFormatString<<"]";
-                        throw std::runtime_error(err.str());
+                        OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, err.str());
                 }
 
                 const UA_DateTime open62541DateTime = UA_DATETIME_UNIX_EPOCH + ((dateTime - unixEpoch).total_seconds() * UA_DATETIME_SEC);
@@ -89,13 +91,13 @@ UaDateTime UaDateTime::fromString(const UaString& dateTimeString)
         {
                 std::ostringstream err;
                 err << "Failed to convert string ["<<stdDateTimeString<<"] to a date, valid format ["<<timeFormatString<<"], error: "<<e.what();
-                throw std::runtime_error(err.str());
+                OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, err.str());
         }
         catch(...)
         {
                 std::ostringstream err;
                 err << "Failed to convert string ["<<stdDateTimeString<<"] to a date, valid format ["<<timeFormatString<<"], unknown error";
-                throw std::runtime_error(err.str());
+                OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, err.str());
         }
 }
 

--- a/src/uanodeid.cpp
+++ b/src/uanodeid.cpp
@@ -11,6 +11,7 @@
 
 #include <uanodeid.h>
 #include <open62541_compat_common.h>
+#include <open62541_compat.h>
 #include <boost/lexical_cast.hpp>
 
 UaNodeId::UaNodeId ():
@@ -72,14 +73,14 @@ IdentifierType UaNodeId::identifierType() const
     {
     case UA_NODEIDTYPE_NUMERIC: return IdentifierType::OpcUa_IdentifierType_Numeric;
     case UA_NODEIDTYPE_STRING: return IdentifierType::OpcUa_IdentifierType_String;
-    default: throw std::runtime_error("not-implemented");
+    default: OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "not-implemented");
     }
 }
 
 UaString UaNodeId::identifierString() const
 {
     if (m_impl.identifierType != UA_NODEIDTYPE_STRING)
-        throw std::runtime_error("asking for identifierString from a non-string identifier!");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "asking for identifierString from a non-string identifier!");
     return UaString( &m_impl.identifier.string );
 
 }
@@ -123,7 +124,7 @@ void UaNodeId::copyTo( UaNodeId* other) const
 void UaNodeId::copyTo( UA_NodeId* other) const
 {
     if (!other)
-        throw std::runtime_error("passed a nullptr");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "passed a nullptr");
     UA_StatusCode status = UA_NodeId_copy( &this->m_impl, other );
     if (status != UA_STATUSCODE_GOOD)
         throw alloc_error();

--- a/src/uaserver.cpp
+++ b/src/uaserver.cpp
@@ -25,6 +25,7 @@
 
 #include <uaserver.h>
 #include <statuscode.h>
+#include <open62541_compat.h>
 
 #include <LogIt.h>
 
@@ -34,11 +35,7 @@
 #include <boost/lexical_cast.hpp>
 #endif // HAS_SERVERCONFIG_LOADER
 
-#define OPEN62541_COMPAT_LOG_AND_THROW(EXCEPTION_TYPE, MSG) \
-    { \
-    LOG(Log::ERR) << MSG; \
-    throw EXCEPTION_TYPE (MSG); \
-    }
+
 
 UaServer::UaServer() :
 m_server(nullptr),

--- a/src/uaserver.cpp
+++ b/src/uaserver.cpp
@@ -57,7 +57,7 @@ void UaServer::start()
         throw std::logic_error ("Establish the 'running flag' first");
     m_server = UA_Server_new();
     if (!m_server)
-        throw std::runtime_error("UA_Server_new failed");
+        OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_Server_new failed");
     UA_ServerConfig* config = UA_Server_getConfig(m_server);
     UA_ServerConfig_setMinimal(config, m_endpointPortNumber, nullptr);
     m_nodeManager->linkServer(m_server);
@@ -121,7 +121,7 @@ void UaServer::setServerConfig(
          {
              LOG(Log::ERR) << "ServerConfig: Problem at " << error.id() << ":" << error.line() << ": " << error.message();
          }
-         throw std::runtime_error("ServerConfig: failed to load ServerConfig. The exact problem description should have been logged.");
+         OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "ServerConfig: failed to load ServerConfig. The exact problem description should have been logged.");
 
      }
      // minimum one endpoint is guaranteed by the XSD, but in case user declared more, refuse to continue
@@ -129,14 +129,14 @@ void UaServer::setServerConfig(
      const ServerConfig::UaServerConfig& uaServerConfig = serverConfig->UaServerConfig();
      if (uaServerConfig.UaEndpoint().size() > 1)
      {
-         throw std::runtime_error("No support for multiple UaEndpoints yet, simplify your ServerConfig.xml");
+         OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "No support for multiple UaEndpoints yet, simplify your ServerConfig.xml");
      }
      boost::regex endpointUrlRegex("^opc\\.tcp:\\/\\/\\[NodeName\\]:(?<port>\\d+)$");
      boost::smatch matchResults;
      std::string endpointUrl (uaServerConfig.UaEndpoint()[0].Url() );
      bool matched = boost::regex_match( endpointUrl, matchResults, endpointUrlRegex );
      if (!matched)
-         throw std::runtime_error("Can't parse UaEndpoint/Url, note it should look like 'opc.tcp://[NodeName]:4841' perhaps with different port number, yours is '"+endpointUrl+"'");
+         OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "Can't parse UaEndpoint/Url, note it should look like 'opc.tcp://[NodeName]:4841' perhaps with different port number, yours is '"+endpointUrl+"'");
      unsigned int endpointUrlPort = boost::lexical_cast<unsigned int>(matchResults["port"]);
      LOG(Log::INF) << "From your [" << configurationFile.toUtf8() << "] loaded endpoint port number: " << endpointUrlPort;
      m_endpointPortNumber = endpointUrlPort;

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -496,7 +496,9 @@ UaStatus UaVariant::toDouble( OpcUa_Double& out ) const
 UaStatus UaVariant::toByteString( UaByteString& out) const
 {
 	if (m_impl->type != &UA_TYPES[UA_TYPES_BYTESTRING])
-		throw std::runtime_error("not-a-bytestring-and-conversion-not-implemented");
+		OPEN62541_COMPAT_LOG_AND_THROW(
+				std::runtime_error,
+				"not-a-bytestring-and-conversion-not-implemented");
 
 	UA_ByteString * encapsulated = static_cast<UA_ByteString*> (m_impl->data); // nasty, isn't it?
 
@@ -508,7 +510,7 @@ UaStatus UaVariant::toByteString( UaByteString& out) const
 UaString UaVariant::toString( ) const
 {
     if (m_impl->type != &UA_TYPES[UA_TYPES_STRING])
-        throw std::runtime_error("not-a-string");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "not-a-string");
     return UaString( (UA_String*)m_impl->data );
 }
 

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -36,7 +36,7 @@ UA_Variant* UaVariant::createAndCheckOpen62541Variant()
 	UA_Variant* open62541Variant = UA_Variant_new();
     if (!open62541Variant)
     {
-    	throw std::runtime_error("UA_Variant_new() returned 0");
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_Variant_new() returned 0");
     }
     return open62541Variant;
 }
@@ -117,7 +117,7 @@ UaVariant::UaVariant( const UaVariant& other)
 {
     const UaStatus status = UA_Variant_copy( other.m_impl, this->m_impl );
     if (! status.isGood())
-      throw std::runtime_error(std::string("UA_Variant_copy failed:") + status.toString().toUtf8() );
+      OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, std::string("UA_Variant_copy failed:") + status.toString().toUtf8() );
     LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
 
@@ -134,7 +134,7 @@ void UaVariant::operator= (const UaVariant &other)
     
     const UaStatus status = UA_Variant_copy( other.m_impl, this->m_impl );
     if (! status.isGood())
-        throw std::runtime_error(std::string("UA_Variant_copy failed:") + status.toString().toUtf8() );
+        OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, std::string("UA_Variant_copy failed:") + status.toString().toUtf8() );
 
     LOG(Log::TRC) << __FUNCTION__ << " m_impl="<<m_impl<<" m_impl.data="<<m_impl->data;
 }
@@ -159,7 +159,7 @@ UaVariant::UaVariant( const UA_Variant& other )
 {
     UA_StatusCode status = UA_Variant_copy( &other, this->m_impl );
     if (status != UA_STATUSCODE_GOOD)
-        throw std::runtime_error("UA_Variant_copy failed");
+        OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_Variant_copy failed");
 }
 
 UaVariant::~UaVariant()
@@ -178,7 +178,7 @@ OpcUaType UaVariant::type() const
 	if (m_impl->type->typeId.identifierType == UA_NODEIDTYPE_NUMERIC)
 	    return static_cast<OpcUaType>( m_impl->type->typeId.identifier.numeric );
 	else
-	    throw std::runtime_error("No support for non built-in data types in variant! (yet)");
+	    OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "No support for non built-in data types in variant! (yet)");
     }
 }
 
@@ -197,7 +197,7 @@ void UaVariant::reuseOrRealloc( const UA_DataType* dataType, void* newValue )
         // TODO throw when failed
         UaStatus status = UA_Variant_setScalarCopy( m_impl, newValue, dataType);
         if (! status.isGood())
-	  throw std::runtime_error(std::string("UA_Variant_setScalarCopy failed:")+status.toString().toUtf8());
+	  OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, std::string("UA_Variant_setScalarCopy failed:")+status.toString().toUtf8());
     }
 }
 
@@ -272,7 +272,7 @@ void UaVariant::setString( const UaString& value )
 void UaVariant::setByteString( const UaByteString& value, bool detach)
 {
 	if (detach)
-		throw std::runtime_error("value detachment not yet implemented");
+		OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     if (m_impl->data != 0)
         UA_Variant_deleteMembers( m_impl );
     UA_StatusCode s = UA_Variant_setScalarCopy( m_impl, value.impl(), &UA_TYPES[UA_TYPES_BYTESTRING]);
@@ -301,7 +301,7 @@ void UaVariant::setBoolArray(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_BOOLEAN], input );
 }
 
@@ -310,7 +310,7 @@ void UaVariant::setSByteArray(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_SBYTE], input );
 }
 
@@ -319,7 +319,7 @@ void UaVariant::setByteArray(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_BYTE], input );
 }
 
@@ -328,7 +328,7 @@ void UaVariant::setInt16Array(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_INT16], input );
 }
 
@@ -337,7 +337,7 @@ void UaVariant::setUInt16Array(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_UINT16], input );
 }
 
@@ -346,7 +346,7 @@ void UaVariant::setInt32Array(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_INT32], input );
 }
 
@@ -355,7 +355,7 @@ void UaVariant::setUInt32Array(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_UINT32], input );
 }
 
@@ -364,7 +364,7 @@ void UaVariant::setInt64Array(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_INT64], input );
 }
 
@@ -373,7 +373,7 @@ void UaVariant::setUInt64Array(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_UINT64], input );
 }
 
@@ -382,7 +382,7 @@ void UaVariant::setFloatArray(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_FLOAT], input );
 }
 
@@ -391,7 +391,7 @@ void UaVariant::setDoubleArray(
         OpcUa_Boolean       bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     set1DArray( &UA_TYPES[UA_TYPES_DOUBLE], input );
 }
 
@@ -408,7 +408,7 @@ void UaVariant::set1DArrayComplexTypes(
     {
         UaStatus status = copyFunction( input[i].impl(), &array[i] );
         if (!status.isGood())
-            throw std::runtime_error("copy function failed: "+status.toString().toUtf8());
+            OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "copy function failed: "+status.toString().toUtf8());
     }
     UA_Variant_setArray( m_impl, array, input.size(), dataType);
 }
@@ -418,7 +418,7 @@ void UaVariant::setStringArray(
         OpcUa_Boolean      bDetach
     )
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     this->set1DArrayComplexTypes(&UA_TYPES[UA_TYPES_STRING], input, &UA_String_copy);
 }
 
@@ -426,7 +426,7 @@ void UaVariant::setByteStringArray(
         UaByteStringArray& input,
         OpcUa_Boolean      bDetach)
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     this->set1DArrayComplexTypes(&UA_TYPES[UA_TYPES_BYTESTRING], input, &UA_ByteString_copy);
 }
 
@@ -434,7 +434,7 @@ void UaVariant::setVariantArray(
         UaVariantArray& input,
         OpcUa_Boolean bDetach)
 {
-    if (bDetach) throw std::runtime_error("value detachment not yet implemented");
+    if (bDetach) OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "value detachment not yet implemented");
     this->set1DArrayComplexTypes(&UA_TYPES[UA_TYPES_VARIANT], input, &UA_Variant_copy);
 }
 


### PR DESCRIPTION
The problem this contribution solves is, in case of catching an exception in wider scope, always know from where it was thrown, without using gdb or coredumps.
This is done by unifying the thrown mechanism (in some consecutive turns the same could be done to alloc_error which btw, I never saw thrown).