### PR TITLE
initialise UA_Logger with anonymous list (seems like the designated -…

### DIFF
--- a/src/uaserver.cpp
+++ b/src/uaserver.cpp
@@ -75,9 +75,9 @@ static void logFromOpen62541 (
 
 static UA_Logger logItLogger =
 {
-		.log = &logFromOpen62541,
-		.context = nullptr,
-		.clear = nullptr
+		&logFromOpen62541,
+		nullptr,
+		nullptr
 };
 
 UaServer::UaServer() :


### PR DESCRIPTION
Have a look, see what you think.

Seems the named- intialiser syntax originally used is C++ 20, if I understand this article correctly https://en.cppreference.com/w/cpp/language/aggregate_initialization).

C++20 rather "aspirational" for msvc2017, I dropped it back to C++11 conformant code.