### PR TITLE
fixed unnecessary cyclic dependency, when not pulling open62541 from github (which btw is pretty arcane)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,12 @@ endif(SERVERCONFIG_LOADER)
 
 if(NOT STANDALONE_BUILD)
   add_library ( open62541-compat OBJECT ${SRCS} )
-  add_custom_target( quasar_opcua_backend_is_ready DEPENDS open62541-compat )
+  if(${PULL_OPEN62541})  # fetching open62541 (NOT default)
+    add_custom_target( quasar_opcua_backend_is_ready DEPENDS open62541-compat )
+  else(${PULL_OPEN62541}) # using bundled open62541 (default)
+      add_custom_target( quasar_opcua_backend_is_ready ) # ready anytime basically.
+  endif(${PULL_OPEN62541})
+
 else()
 
   # We need some C++11 (via cmake platform agnostic flag)


### PR DESCRIPTION
Intro:
CMake's target called "quasar_opcua_backend_is_ready" is IMO not a carefully chosen name: it should rather be named sth like "quasar_opcua_backend_headers_available" or alike. It originated in times when we used to fetch open62541 rather than use the bundle (anybody still remembers the days??) With such fetching some careful tweaking was necessary to integrate such quasar projects into Yocto's parent CMakeLists ... these days though we have the o6 bundle so in the default mode, that dependency can be relaxed (or, it seems). Doing so gives favourable properties of being able to use open62541-compat not only as quasar's build-time module but also source module.