### PR TITLE
Opcua 2413 open62541 enhancements for mirror variable optional module compatibility

### DIFF
--- a/doc/ChangeLog.html
+++ b/doc/ChangeLog.html
@@ -5,7 +5,7 @@
     <title>open62541-compat ChangeLog</title>
   </head>
   <body>
-    <table width="100%" cellspacing="2" cellpadding="2" border="1">
+    <table cellspacing="2" cellpadding="2" border="1" width="100%">
       <tbody>
         <tr>
           <td valign="top"><b>Version</b><b><br>
@@ -18,40 +18,62 @@
             </b></td>
         </tr>
         <tr>
-          <td valign="top">1.4.0<br>
-            <font size="-2">(02-Jul-2021)</font><br>
+          <td valign="top">1.4.1<br>
+            <font size="-2">(12-Aug-2021)</font><br>
           </td>
-          <td valign="top">
-            <br>
-            Bug
-            <br>
-            <ul>
-              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2419">OPCUA-2419</a>]
-                - addPropertyNodeAndReference not setting DataType
-                correctly
-              </li>
-            </ul>
-            <br>
-            New Feature
+          <td valign="top"><br>
+            Task
             <br>
             <ul>
-              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2362">OPCUA-2362</a>]
-                - NodeId printing support for UaVariant
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2443">OPCUA-2443</a>]
+                - Add example client program
               </li>
-              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2363">OPCUA-2363</a>]
-                - Profit from UA_print
-              </li>
-              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2364">OPCUA-2364</a>]
-                - With open62541 1.2.2
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2444">OPCUA-2444</a>]
+                - UaVariant::toString superflouous quotes for string
+                (toSameTypeTestFailing ?)
               </li>
             </ul>
             <br>
             Improvement
             <br>
             <ul>
-              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2427">OPCUA-2427</a>]
-                - Add missing OpcUaId_... for built in data-types
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2392">OPCUA-2392</a>]
+                - Controlling the order (or the place) in which / at
+                which piping configuration kicks in
               </li>
+            </ul>
+          </td>
+          <td valign="top">1.2.2<br>
+            (bundled) </td>
+          <td valign="top">(-)<br>
+          </td>
+        </tr>
+        <tr>
+          <td valign="top">1.4.0<br>
+            <font size="-2">(02-Jul-2021)</font><br>
+          </td>
+          <td valign="top"> <br>
+            Bug <br>
+            <ul>
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2419">OPCUA-2419</a>]
+                - addPropertyNodeAndReference not setting DataType
+                correctly </li>
+            </ul>
+            <br>
+            New Feature <br>
+            <ul>
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2362">OPCUA-2362</a>]
+                - NodeId printing support for UaVariant </li>
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2363">OPCUA-2363</a>]
+                - Profit from UA_print </li>
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2364">OPCUA-2364</a>]
+                - With open62541 1.2.2 </li>
+            </ul>
+            <br>
+            Improvement <br>
+            <ul>
+              <li>[<a href="https://its.cern.ch/jira/browse/OPCUA-2427">OPCUA-2427</a>]
+                - Add missing OpcUaId_... for built in data-types </li>
             </ul>
           </td>
           <td valign="top">1.2.2<br>
@@ -438,6 +460,8 @@
             can be deployed independently from quasar, that is e.g. via
             "make install". The profit of it is <a
               href="https://its.cern.ch/jira/browse/OPCUA-1632">explained
+
+
 
 
 

--- a/include/other.h
+++ b/include/other.h
@@ -60,6 +60,7 @@ class UaQualifiedName
     UaQualifiedName(int ns, const UaString& name);
     UA_QualifiedName impl() const { return m_impl; }
     UaString unqualifiedName() const { return m_unqualifiedName; }
+    UaString toFullString() const;
   private:
     UaString m_unqualifiedName;
     UA_QualifiedName m_impl;

--- a/include/other.h
+++ b/include/other.h
@@ -60,6 +60,7 @@ class UaQualifiedName
     UaQualifiedName(int ns, const UaString& name);
     UA_QualifiedName impl() const { return m_impl; }
     UaString unqualifiedName() const { return m_unqualifiedName; }
+    UaString toString() const;
     UaString toFullString() const;
   private:
     UaString m_unqualifiedName;

--- a/include/uadatavalue.h
+++ b/include/uadatavalue.h
@@ -32,6 +32,7 @@ class UaDataValue
     UaDataValue( const UaDataValue& other );
     void operator=(const UaDataValue& other );
     bool operator==(const UaDataValue &other) const;
+    bool operator!=(const UaDataValue &other) const;
 
     ~UaDataValue ();
 

--- a/include/uadatavalue.h
+++ b/include/uadatavalue.h
@@ -31,6 +31,7 @@ class UaDataValue
     UaDataValue( const UaVariant& variant, OpcUa_StatusCode statusCode, const UaDateTime& serverTime, const UaDateTime& sourceTime );
     UaDataValue( const UaDataValue& other );
     void operator=(const UaDataValue& other );
+    bool operator==(const UaDataValue &other) const;
 
     ~UaDataValue ();
 

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -33,9 +33,17 @@ UaQualifiedName::UaQualifiedName(int ns, const UaString& name):
     m_impl.namespaceIndex = ns;
 }
 
+UaString  UaQualifiedName::toString() const
+{
+    return UaString(m_impl.name);
+}
+
 UaString  UaQualifiedName::toFullString() const
 {
-    throw new std::runtime_error(" UaQualifiedName::toFullString() - missing implementation");
+    std::ostringstream result;
+    result << "ns="<<m_impl.namespaceIndex << "|" << UaString(m_impl.name).toUtf8();
+    return UaString(result.str().c_str());
+//    throw new std::runtime_error(" UaQualifiedName::toFullString() - missing implementation");
 }
 
 UaLocalizedText::UaLocalizedText( const char* locale, const char* text) 

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -33,6 +33,11 @@ UaQualifiedName::UaQualifiedName(int ns, const UaString& name):
     m_impl.namespaceIndex = ns;
 }
 
+UaString  UaQualifiedName::toFullString() const
+{
+    throw new std::runtime_error(" UaQualifiedName::toFullString() - missing implementation");
+}
+
 UaLocalizedText::UaLocalizedText( const char* locale, const char* text) 
 {
     m_impl = UA_LOCALIZEDTEXT_ALLOC( locale, text ); 

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -43,7 +43,6 @@ UaString  UaQualifiedName::toFullString() const
     std::ostringstream result;
     result << "ns="<<m_impl.namespaceIndex << "|" << UaString(m_impl.name).toUtf8();
     return UaString(result.str().c_str());
-//    throw new std::runtime_error(" UaQualifiedName::toFullString() - missing implementation");
 }
 
 UaLocalizedText::UaLocalizedText( const char* locale, const char* text) 

--- a/src/uadatavalue.cpp
+++ b/src/uadatavalue.cpp
@@ -69,6 +69,11 @@ void UaDataValue:: operator=(const UaDataValue& other )
 
 }
 
+bool UaDataValue:: operator==(const UaDataValue &other) const
+{
+    throw std::runtime_error(" UaDataValue:: operator== not implemented yet!");
+}
+
 UaDataValue UaDataValue::clone()
 {
     while (m_lock.test_and_set(std::memory_order_acquire));  // acquire lock

--- a/src/uadatavalue.cpp
+++ b/src/uadatavalue.cpp
@@ -71,12 +71,22 @@ void UaDataValue:: operator=(const UaDataValue& other )
 
 bool UaDataValue:: operator==(const UaDataValue &other) const
 {
-    throw std::runtime_error(" UaDataValue:: operator== not implemented yet!");
+    if(this == &other) return true;
+    if(m_impl->status == other.m_impl->status
+    && m_impl->serverTimestamp == other.m_impl->serverTimestamp
+    && m_impl->sourceTimestamp == other.m_impl->sourceTimestamp 
+    )
+    {
+        // compare values - apparently no direct open62541 comparator, so, compare via compat API
+        return UaVariant(m_impl->value) == UaVariant(other.m_impl->value);
+    }
+
+    return false;
 }
 
 bool UaDataValue:: operator!=(const UaDataValue &other) const
 {
-    throw std::runtime_error(" UaDataValue:: operator!= not implemented yet!");
+    return !(*this == other);
 }
 
 UaDataValue UaDataValue::clone()

--- a/src/uadatavalue.cpp
+++ b/src/uadatavalue.cpp
@@ -74,6 +74,11 @@ bool UaDataValue:: operator==(const UaDataValue &other) const
     throw std::runtime_error(" UaDataValue:: operator== not implemented yet!");
 }
 
+bool UaDataValue:: operator!=(const UaDataValue &other) const
+{
+    throw std::runtime_error(" UaDataValue:: operator!= not implemented yet!");
+}
+
 UaDataValue UaDataValue::clone()
 {
     while (m_lock.test_and_set(std::memory_order_acquire));  // acquire lock

--- a/src/uadatavalue.cpp
+++ b/src/uadatavalue.cpp
@@ -72,10 +72,9 @@ void UaDataValue:: operator=(const UaDataValue& other )
 bool UaDataValue:: operator==(const UaDataValue &other) const
 {
     if(this == &other) return true;
-    if(m_impl->status == other.m_impl->status
-    && m_impl->serverTimestamp == other.m_impl->serverTimestamp
-    && m_impl->sourceTimestamp == other.m_impl->sourceTimestamp 
-    )
+    if(m_impl->status == other.m_impl->status &&
+       m_impl->serverTimestamp == other.m_impl->serverTimestamp &&
+       m_impl->sourceTimestamp == other.m_impl->sourceTimestamp)
     {
         // compare values - apparently no direct open62541 comparator, so, compare via compat API
         return UaVariant(m_impl->value) == UaVariant(other.m_impl->value);

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -136,8 +136,14 @@ bool UaVariant::operator==(const UaVariant& other) const
 	{
 		if(m_impl->arrayDimensions[arrayDimensionIndex] != other.m_impl->arrayDimensions[arrayDimensionIndex]) return false;
 	}
-	if(0 != memcmp(m_impl->data, other.m_impl->data, m_impl->arrayLength)) return false;
-
+    if(type() == OpcUaType_String)
+    {
+        return toString() == other.toString();
+    }
+    else
+    {
+	    if(0 != memcmp(m_impl->data, other.m_impl->data, m_impl->arrayLength)) return false;
+    }
 	return true;
 }
 

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -509,11 +509,17 @@ UaString UaVariant::toString( ) const
 	}
 	else
 	{
-		UA_String* output (UA_String_new());
-		UA_print(m_impl->data, m_impl->type, output);
-		UaString rtrn (output);
-		UA_String_clear(output);
-		return rtrn;
+		// UA_print can't be used for strings because it wraps stuff in quotes
+	    if (m_impl->type == &UA_TYPES[UA_TYPES_STRING])
+	    	return UaString( (UA_String*)m_impl->data );
+	    else
+	    {
+			UA_String* output (UA_String_new());
+			UA_print(m_impl->data, m_impl->type, output);
+			UaString rtrn (output);
+			UA_String_clear(output);
+			return rtrn;
+	    }
 	}
 }
 

--- a/test/src/uadatavalue_test.cpp
+++ b/test/src/uadatavalue_test.cpp
@@ -8,14 +8,24 @@
 #include "gtest/gtest.h"
 #include <uadatavalue.h>
 
+const auto g_sValueVariant = UaVariant(UaString("some string value"));
+const auto g_sSourceTime = UaDateTime::fromString(UaString("2021-08-02T14:30:00Z"));
+const auto g_sServerTime = UaDateTime::fromString(UaString("2021-08-02T14:30:01Z"));
+
 TEST(UaDataValueTest, testOperatorIsEqual)
 {
-    UaDataValue testee( UaVariant("some string value"), OpcUa_Good, UaDateTime::now(), UaDateTime::now() );
+    UaDataValue testee(g_sValueVariant , OpcUa_Good, g_sServerTime, g_sSourceTime );
     EXPECT_TRUE(testee == testee);
+    EXPECT_TRUE(testee == UaDataValue( g_sValueVariant, OpcUa_Good, g_sServerTime, g_sSourceTime ) ) << "equivalent object";
+    EXPECT_FALSE(testee == UaDataValue( UaVariant(UaString("DIFFERENT string value")), OpcUa_Good, g_sServerTime, g_sSourceTime ) ) << "value changed";
+    EXPECT_FALSE(testee == UaDataValue( UaVariant(OpcUa_Int32(69)), OpcUa_Good, g_sServerTime, g_sSourceTime ) ) << "type changed";
+    EXPECT_FALSE(testee == UaDataValue( g_sValueVariant, OpcUa_Bad, g_sServerTime, g_sSourceTime ) ) << "status changed";
+    EXPECT_FALSE(testee == UaDataValue( g_sValueVariant, OpcUa_Good, UaDateTime::fromString("2222-08-02T14:30:01Z"), g_sSourceTime ) ) << "server timestamp changed";
+    EXPECT_FALSE(testee == UaDataValue( g_sValueVariant, OpcUa_Good, g_sServerTime, UaDateTime::fromString("2222-08-02T14:30:01Z") ) )<< "source timestamp changed";
 }
 
 TEST(UaDataValueTest, testOperatorNotIsEqual)
 {
-    UaDataValue testee( UaVariant("some string value"), OpcUa_Good, UaDateTime::now(), UaDateTime::now() );
-    EXPECT_TRUE(testee != testee);
+    UaDataValue testee( UaVariant("some string value"), OpcUa_Good, g_sServerTime, g_sSourceTime );
+    EXPECT_FALSE(testee != testee);
 }

--- a/test/src/uadatavalue_test.cpp
+++ b/test/src/uadatavalue_test.cpp
@@ -14,3 +14,8 @@ TEST(UaDataValueTest, testOperatorIsEqual)
     EXPECT_TRUE(testee == testee);
 }
 
+TEST(UaDataValueTest, testOperatorNotIsEqual)
+{
+    UaDataValue testee( UaVariant("some string value"), OpcUa_Good, UaDateTime::now(), UaDateTime::now() );
+    EXPECT_TRUE(testee != testee);
+}

--- a/test/src/uadatavalue_test.cpp
+++ b/test/src/uadatavalue_test.cpp
@@ -1,0 +1,16 @@
+/*
+ * uadatavalue_test.cpp
+ *
+ *  Created on: 16 July 2021
+ *      Author: ben-farnham 
+ */
+
+#include "gtest/gtest.h"
+#include <uadatavalue.h>
+
+TEST(UaDataValueTest, testOperatorIsEqual)
+{
+    UaDataValue testee( UaVariant("some string value"), OpcUa_Good, UaDateTime::now(), UaDateTime::now() );
+    EXPECT_TRUE(testee == testee);
+}
+

--- a/test/src/uaqualifiedname_test.cpp
+++ b/test/src/uaqualifiedname_test.cpp
@@ -1,0 +1,15 @@
+/*
+ * uaqualifiedname_test.cpp
+ *
+ *  Created on: 16 July 2021
+ *      Author: ben-farnham 
+ */
+
+#include "gtest/gtest.h"
+
+#include <other.h>
+
+TEST(UaQualifiedNameTest, testDefaultConstructor)
+{
+    EXPECT_EQ(true, false) << "WTF ?";
+}

--- a/test/src/uaqualifiedname_test.cpp
+++ b/test/src/uaqualifiedname_test.cpp
@@ -6,10 +6,18 @@
  */
 
 #include "gtest/gtest.h"
+#include <other.h>
 
 #include <other.h>
 
-TEST(UaQualifiedNameTest, testDefaultConstructor)
+TEST(UaQualifiedNameTest, testToString)
 {
-    EXPECT_EQ(true, false) << "WTF ?";
+    UaQualifiedName testee(2, "a.b.c");
+    EXPECT_EQ("a.b.c", testee.toString().toUtf8());
+}
+
+TEST(UaQualifiedNameTest, testToFullString)
+{
+    UaQualifiedName testee(2, "a.b.c");
+    EXPECT_EQ("ns=2|a.b.c", testee.toFullString().toUtf8());
 }

--- a/test/src/uavariant_test.cpp
+++ b/test/src/uavariant_test.cpp
@@ -50,7 +50,7 @@ TEST_F(UaVariantTest, testConvertToSameInternalType)
 	EXPECT_EQ(uint64Value, uint64Result);
 
 	m_testee.setString(UaString("abcde"));
-	EXPECT_EQ("\"abcde\"", m_testee.toString().toUtf8());
+	EXPECT_EQ("abcde", m_testee.toString().toUtf8());
 }
 
 TEST_F(UaVariantTest, testConvertFromBoolean)

--- a/test/src/uavariant_test.cpp
+++ b/test/src/uavariant_test.cpp
@@ -50,7 +50,7 @@ TEST_F(UaVariantTest, testConvertToSameInternalType)
 	EXPECT_EQ(uint64Value, uint64Result);
 
 	m_testee.setString(UaString("abcde"));
-	EXPECT_EQ("abcde", m_testee.toString().toUtf8());
+	EXPECT_EQ("\"abcde\"", m_testee.toString().toUtf8());
 }
 
 TEST_F(UaVariantTest, testConvertFromBoolean)

--- a/test/src/uavariant_test.cpp
+++ b/test/src/uavariant_test.cpp
@@ -172,3 +172,11 @@ TEST_F(UaVariantTest, testConvertFromUInt32)
 	EXPECT_EQ(OpcUa_Good, m_testee.toInt32(int32Result));
 	EXPECT_EQ(numeric_limits<int32_t>::max(), int32Result);
 }
+
+TEST_F(UaVariantTest, testisEqualOperatorForStringVariants)
+{
+	m_testee.setString("some string value");
+	EXPECT_TRUE(m_testee == m_testee);
+	EXPECT_TRUE(m_testee == UaVariant(UaString("some string value")));
+	EXPECT_FALSE(m_testee == UaVariant(UaString("DIFFERENT string value")));
+}


### PR DESCRIPTION
Hi folks,

This is an open62541-compat PR required for the Mirror Variables optional module to work. However, the changes stand on their onw: basically filling in some more of the missing API implementation that unified automation has, but open62541-compat does not yet.

A core requirement of Mirror Variables is that we can compare UaDataValues (to know when the mirrored & mirroree both have the same value - so that the mirroring process can stop). So, basically the addition of '==' and '!=' operators.

@pnikiel : I already upmerged your most recent branch (OPCUA-2444_test_failing_string_quotes) to this branch to make sure there was no potential for clash.

Reviews most welcome !
