### PR TITLE
OPCUA-3179 stream inserter operator added

### DIFF
--- a/include/other.h
+++ b/include/other.h
@@ -24,6 +24,7 @@
 
 #include <open62541.h>
 #include <uastring.h>
+#include <ostream>
 //TODO: amalgamated or not
 
 
@@ -55,6 +56,8 @@ class UaQualifiedName
     UaString m_unqualifiedName;
     UA_QualifiedName m_impl;
 };
+
+std::ostream& operator<<(std::ostream& os, const UaQualifiedName& n);
 
 class UaMutexRefCounted {};
 

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -108,3 +108,9 @@ OpcUa_NodeClass safeConvertNodeClassToSdk (UA_NodeClass nc)
 				"This node class is not implemented: " + std::to_string(nc) + ", improve me!");
 	}
 }
+
+std::ostream& operator<<(std::ostream& os, const UaQualifiedName& n)
+{
+	os << n.toString().toUtf8();
+	return os;
+}


### PR DESCRIPTION
UaNode::browseName() returns type UaQualifiedName

Using UASDK, UaQualifiedName is compatible with stream inserter operator, for example this (pseudo) code is valid

```
UaNode someNode(whatever);
std::cout << "hellow, world. I am node ["<<someNode.browseName()<<"]" << std::endl;

```
The same code is not valid when open62541-compat (no stream insertion operator is defined for the UaQualifiedName type).

Extend open62541-compat to have equivalent behaviour with UASDK.