### PR TITLE
Align cmake_minimum_required 3.5 -> 3.16 with quasar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # Piotr Nikiel <piotr@nikiel.info>
 # Ben Farnham <firstNm.secondNm@cern.ch>
 project(open62541-compat LANGUAGES C CXX)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 cmake_policy(SET CMP0012 NEW)
 cmake_policy(SET CMP0057 NEW) # enables IN_LIST operator
 

--- a/boost_standard_install.cmake
+++ b/boost_standard_install.cmake
@@ -16,7 +16,7 @@
 
 # Authors:
 # Ben Farnham <firstNm.secondNm@cern.ch>
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 3.16 )
 #project( FindSystemBoost CXX )
 message(STATUS "Using file [boost_standard_install.cmake] toolchain file")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(open62541-compat-Test)
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
Follow-up to OPCUA-3334 (#104), which set the floor to 3.5 (the minimum CMake 4.x requires). Raise it to **3.16** to match the quasar framework's standardized minimum (OPCUA-3365) and the rest of the ecosystem (mule, core), so we have one consistent floor.

3.16 stays well clear of CMake 4.x's 3.5 deprecation and below AlmaLinux 9's default CMake (3.26). Root `CMakeLists.txt`, `boost_standard_install.cmake`, and `test/CMakeLists.txt` all moved; the FetchContent template (`CMakeLists.cmake.in`) is left on `${CMAKE_VERSION}` (dynamic).