### PR TITLE
OPCUA-3384 Do not treat warnings as errors on the vendored open62541 amalgamation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ SET( SRCS
 if(NOT ${PULL_OPEN62541})  # this is the default behaviour
 	include_directories(extern/open62541/include)
 	list(APPEND SRCS extern/open62541/src/open62541.c)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -DUA_ARCHITECTURE_POSIX -Werror -Wall -Wextra -Wpedantic -Wno-static-in-inline -Wno-overlength-strings -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wredundant-decls -Wformat -Wformat-security -Wformat-nonliteral -Wuninitialized -Winit-self -Wcast-qual -Wstrict-overflow -Wnested-externs -Wmultichar -Wundef -Wc++-compat -fno-strict-aliasing -fexceptions -fstack-protector-strong  -Wno-unused-function -Wshadow -Wconversion -fvisibility=hidden")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -DUA_ARCHITECTURE_POSIX -Wall -Wextra -Wpedantic -Wno-static-in-inline -Wno-overlength-strings -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wredundant-decls -Wformat -Wformat-security -Wformat-nonliteral -Wuninitialized -Winit-self -Wcast-qual -Wstrict-overflow -Wnested-externs -Wmultichar -Wundef -Wc++-compat -fno-strict-aliasing -fexceptions -fstack-protector-strong  -Wno-unused-function -Wshadow -Wconversion -fvisibility=hidden")
 endif(NOT ${PULL_OPEN62541})
 
 if(${PULL_OPEN62541})  # this is not default


### PR DESCRIPTION
Resolves OPCUA-3384.

The default bundled build compiles the vendored open62541 amalgamation `extern/open62541/src/open62541.c` with a `CMAKE_C_FLAGS` set that includes `-Werror` (CMakeLists.txt:85, unchanged since 2019 and identical across v1.4.3-rc0..v1.4.5 and master). Newer compilers emit additional diagnostics on this third-party upstream code and fatally fail the build:

- clang 21: 3x `-Wstrict-prototypes` (open62541.c:56546/68539/69223) + 4x `-Wenum-enum-conversion` (open62541.c:20308/21417/25135/44963)
- the same warnings also surface under gcc 16

This is the 33% link wall hit by quasar's clang work (OPCUA-3341).

## Fix
Remove only the `-Werror` token from the `CMAKE_C_FLAGS` string at CMakeLists.txt:85. `-Wall -Wextra -Wpedantic` and every other `-W` flag stay; warnings remain visible but non-fatal. No `-Wno-error` whack-a-mole, no new flags.

`CMAKE_C_FLAGS` governs C compilation only, and the sole `.c` file in the build is the vendored amalgamation. All of open62541-compat's own sources are `.cpp` compiled with CXX flags, so this does not affect compat's own code.

## Validation (empirical, in containers)
- clang 21.1.8: fixed flags compile the amalgamation (object produced); control with `-Werror` re-added fails with exactly the 7 errors above.
- gcc 16.1.0 regression: compiles cleanly with the fixed flags (0 errors, 0 warnings) — original compiler not regressed.
- Full `libopen62541-compat.a` builds and links under clang 21.
- End to end: a quasar open62541 `OpcUaServer` links under clang against this branch; the 33% wall passes.

Single-line diff at CMakeLists.txt:85.
