### PR TITLE
DCS-615: fix Windows builds (amalgamation baked UA_ARCHITECTURE_POSIX) + Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,34 @@
+name: Windows CI
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: windows-2022
+    env:
+      WINDOWS_DEPENDENCIES_DIR: C:\quasar-windows-dependencies
+      BOOST_PATH_HEADERS: C:\quasar-windows-dependencies\boost\lib\native\include
+      BOOST_PATH_LIBS: C:\quasar-windows-dependencies
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install boost (prebuilt vc141 1.67.0 via nuget, same recipe as appveyor.yml)
+        shell: cmd
+        run: nuget install boost-vc141 -Version 1.67.0 -NonInteractive -ExcludeVersion -OutputDirectory %WINDOWS_DEPENDENCIES_DIR%
+
+      - name: Configure
+        shell: cmd
+        run: cmake -B build -DSTANDALONE_BUILD=ON -DOPEN62541-COMPAT_BUILD_CONFIG_FILE=boost_appveyor_ci.cmake -G "Visual Studio 17 2022" -A x64
+
+      - name: Build
+        shell: cmd
+        run: cmake --build build --config Release --parallel
+
+      - name: Test
+        shell: cmd
+        run: build\test\Release\open62541-compat-Test.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ if(NOT ${PULL_OPEN62541})  # this is the default behaviour
 	if(APPLE)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DARWIN_C_SOURCE=1")
 	endif()
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -DUA_ARCHITECTURE_POSIX -Wall -Wextra -Wpedantic -Wno-static-in-inline -Wno-overlength-strings -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wredundant-decls -Wformat -Wformat-security -Wformat-nonliteral -Wuninitialized -Winit-self -Wcast-qual -Wstrict-overflow -Wnested-externs -Wmultichar -Wundef -Wc++-compat -fno-strict-aliasing -fexceptions -fstack-protector-strong  -Wno-unused-function -Wshadow -Wconversion -fvisibility=hidden")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -Wextra -Wpedantic -Wno-static-in-inline -Wno-overlength-strings -Wno-unused-parameter -Wmissing-prototypes -Wstrict-prototypes -Wredundant-decls -Wformat -Wformat-security -Wformat-nonliteral -Wuninitialized -Winit-self -Wcast-qual -Wstrict-overflow -Wnested-externs -Wmultichar -Wundef -Wc++-compat -fno-strict-aliasing -fexceptions -fstack-protector-strong  -Wno-unused-function -Wshadow -Wconversion -fvisibility=hidden")
 endif(NOT ${PULL_OPEN62541})
 
 if(${PULL_OPEN62541})  # this is not default
@@ -182,7 +182,7 @@ else()
   target_link_libraries( open62541-compat ${BOOST_LIBS} ${OPEN62541_SDK_LIB} ${LOGITLIB})
 
   if(WIN32)
-    target_link_libraries( open62541-compat ws2_32 )
+    target_link_libraries( open62541-compat ws2_32 iphlpapi )
   endif()
 
   #

--- a/extern/open62541/include/open62541.h
+++ b/extern/open62541/include/open62541.h
@@ -41,7 +41,7 @@
  * Define one of the following. */
 
 /* #undef UA_ARCHITECTURE_WIN32 */
-#define UA_ARCHITECTURE_POSIX
+/* #undef UA_ARCHITECTURE_POSIX */
 /* #undef UA_ARCHITECTURE_ZEPHYR */
 /* #undef UA_ARCHITECTURE_LWIP */
 /* #undef UA_ARCHITECTURE_FREERTOS */

--- a/extern/open62541/prepare_open62541.sh
+++ b/extern/open62541/prepare_open62541.sh
@@ -26,6 +26,7 @@ cd $WD
 
 # deploy files
 find tmp -name open62541.h -ok cp {} include \; || exit
+sed -i.bak 's|^#define UA_ARCHITECTURE_POSIX$|/* #undef UA_ARCHITECTURE_POSIX */|' include/open62541.h && rm -f include/open62541.h.bak
 printf '\n#if defined(__cplusplus) && defined(UA_HAVE_C11_ATOMICS)\n#undef _Atomic\n#undef atomic_uintptr_t\n#endif\n' >> include/open62541.h
 find tmp -name open62541.c -ok cp {} src \; || exit
 


### PR DESCRIPTION
## What

The 1.5.4 amalgamation (PR #107) baked the generation host's architecture — an unconditional `#define UA_ARCHITECTURE_POSIX` ahead of the header's own per-platform fallback — so Windows builds compiled POSIX socket code (`sys/socket.h: No such file or directory`). Tracked as [DCS-615](https://its.cern.ch/jira/browse/DCS-615).

- Neutralize the baked define (header now matches its `/* #undef ... */` siblings; the `_WIN32` fallback decides per platform), and teach `prepare_open62541.sh` to do the same on every future regeneration.
- Drop the now-redundant `-DUA_ARCHITECTURE_POSIX` compile flag (it also reached MSVC, where it would re-break Windows on its own).
- Link `iphlpapi` on Windows (`GetAdaptersAddresses`, new in the 1.5 stack — empirically confirmed via link test).
- Add a **Windows CI workflow** (GitHub Actions, windows-2022 + MSVC, the `appveyor.yml` boost recipe) — replaces the stale AppVeyor as the Windows gate and serves [DCS-616](https://its.cern.ch/jira/browse/DCS-616).

## Verification

- Pre-fix repro (mingw-w64 cross): header selects POSIX → `sys/socket.h` fatal error.
- Post-fix (mingw-w64): header selects `UA_ARCHITECTURE_WIN32`; amalgamation compiles; minimal server links with exactly `ws2_32 iphlpapi`.
- **MSVC, real Windows runner**: full configure+build+**test suite green** — https://github.com/parasxos/open62541-compat/actions/runs/27294461378
- POSIX regression: full AlmaLinux 9 standalone rebuild with fallback-selected arch, 29/29 tests pass.