### PR TITLE
UASDK fidelity batch: OPCUA-3400..3405 (headers, operators, ByteString semantics, empty arrays)

### DIFF
--- a/include/opcua_p_types.h
+++ b/include/opcua_p_types.h
@@ -1,0 +1,24 @@
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
+ * opcua_p_types.h
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPEN62541_COMPAT_INCLUDE_OPCUA_P_TYPES_H_
+#define OPEN62541_COMPAT_INCLUDE_OPCUA_P_TYPES_H_
+
+#include <opcua_platformdefs.h>
+
+#endif /* OPEN62541_COMPAT_INCLUDE_OPCUA_P_TYPES_H_ */

--- a/include/uanodeid.h
+++ b/include/uanodeid.h
@@ -66,6 +66,7 @@ public:
     void copyTo( UA_NodeId* other) const;
     void copyTo( UaNodeId* other) const;
     bool operator==(const UaNodeId& other) const;
+    bool operator!=(const UaNodeId& other) const { return !(*this == other); }
 private:
     /* UaString m_stringId; */
     UA_NodeId m_impl;

--- a/include/uavariant.h
+++ b/include/uavariant.h
@@ -28,6 +28,7 @@
 #include <statuscode.h>
 #include <uadatetime.h>
 #include <uabytestring.h>
+#include <uanodeid.h>
 #include <other.h>
 #include <simple_arrays.h>
 
@@ -75,9 +76,11 @@ class UaVariant
 
   ~UaVariant();
   OpcUaType type() const;
-    
+  UaNodeId dataType() const { return UaNodeId(static_cast<OpcUa_UInt32>(type()), 0); }
+
   // setters
   void setBool( OpcUa_Boolean value );
+  void setBoolean( OpcUa_Boolean value ) { setBool(value); }
   void setByte( OpcUa_Byte value );
   void setSByte( OpcUa_SByte value );
   void setInt16( OpcUa_Int16 value );
@@ -95,6 +98,7 @@ class UaVariant
   void setByteString( const UaByteString& value, bool detach);
 
   void setBoolArray( UaBooleanArray& val, OpcUa_Boolean bDetach = OpcUa_False);
+  void setBooleanArray( UaBooleanArray& val, OpcUa_Boolean bDetach = OpcUa_False) { setBoolArray(val, bDetach); }
   void setSByteArray( UaSByteArray& val, OpcUa_Boolean bDetach = OpcUa_False);
   void setByteArray( UaByteArray& val, OpcUa_Boolean bDetach = OpcUa_False );
   void setInt16Array( UaInt16Array& val, OpcUa_Boolean bDetach = OpcUa_False);
@@ -115,6 +119,7 @@ class UaVariant
 
   // getters
   UaStatus toBool( OpcUa_Boolean& value) const;
+  OpcUa_StatusCode toBoolean( OpcUa_Boolean& value) const { return toBool(value); }
   UaStatus toInt16( OpcUa_Int16& value) const;
   UaStatus toUInt16( OpcUa_UInt16& value) const;
   UaStatus toInt32( OpcUa_Int32& value ) const;
@@ -131,6 +136,7 @@ class UaVariant
   UaString toFullString() const;
 
   OpcUa_StatusCode toBoolArray( UaBooleanArray& out ) const;
+  OpcUa_StatusCode toBooleanArray( UaBooleanArray& out ) const { return toBoolArray(out); }
   OpcUa_StatusCode toSByteArray( UaSByteArray& out ) const;
   OpcUa_StatusCode toByteArray( UaByteArray& out ) const;
   OpcUa_StatusCode toInt16Array( UaInt16Array& out ) const;

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -277,12 +277,14 @@ void UaVariant::set1DArray( const UA_DataType* dataType, const ArrayType& input 
 {
     if (m_impl->data != 0)
         UA_Variant_clear( m_impl );
-    const void* rawInput = 0;
-    if (input.size()>0)
-        rawInput = &input[0];
+    if (input.size() == 0)
+    {
+        UA_Variant_setArray( m_impl, UA_Array_new(0, dataType), 0, dataType );
+        return;
+    }
     if (UA_Variant_setArrayCopy(
             m_impl,
-            rawInput,
+            &input[0],
             input.size(),
             dataType) != UA_STATUSCODE_GOOD)
         throw alloc_error();
@@ -493,16 +495,25 @@ UaStatus UaVariant::toDouble( OpcUa_Double& out ) const
 
 UaStatus UaVariant::toByteString( UaByteString& out) const
 {
-	if (m_impl->type != &UA_TYPES[UA_TYPES_BYTESTRING])
-		OPEN62541_COMPAT_LOG_AND_THROW(
-				std::runtime_error,
-				"not-a-bytestring-and-conversion-not-implemented");
+	if (!m_impl || !m_impl->data)
+		return OpcUa_BadTypeMismatch;
 
-	UA_ByteString * encapsulated = static_cast<UA_ByteString*> (m_impl->data); // nasty, isn't it?
+	if (m_impl->type == &UA_TYPES[UA_TYPES_BYTESTRING] && isScalarValue())
+	{
+		UA_ByteString * encapsulated = static_cast<UA_ByteString*> (m_impl->data); // nasty, isn't it?
+		out.setByteString( encapsulated->length, encapsulated->data );
+		return OpcUa_Good;
+	}
 
-	out.setByteString( encapsulated->length, encapsulated->data );
+	if (m_impl->type == &UA_TYPES[UA_TYPES_BYTE] && !isScalarValue())
+	{
+		out.setByteString(
+				static_cast<long>(m_impl->arrayLength),
+				static_cast<OpcUa_Byte*>(m_impl->data == UA_EMPTY_ARRAY_SENTINEL ? nullptr : m_impl->data) );
+		return OpcUa_Good;
+	}
 
-	return OpcUa_Good;
+	return OpcUa_BadTypeMismatch;
 }
 
 UaString UaVariant::toString( ) const
@@ -764,7 +775,7 @@ bool UaVariant::isScalarValue() const
 {
 	if(m_impl && m_impl->data) // internal value exists and has data
 	{
-	    return m_impl->arrayLength == 0;
+	    return m_impl->arrayLength == 0 && m_impl->data > UA_EMPTY_ARRAY_SENTINEL;
 	}
 	return false;
 }

--- a/test/src/uavariant_test.cpp
+++ b/test/src/uavariant_test.cpp
@@ -180,3 +180,89 @@ TEST_F(UaVariantTest, testisEqualOperatorForStringVariants)
 	EXPECT_TRUE(m_testee == UaVariant(UaString("some string value")));
 	EXPECT_FALSE(m_testee == UaVariant(UaString("DIFFERENT string value")));
 }
+
+TEST_F(UaVariantTest, testDataTypeReturnsBuiltinNodeId)
+{
+	m_testee.setInt32(42);
+	EXPECT_TRUE(m_testee.dataType() == UaNodeId(OpcUaType_Int32, 0));
+	EXPECT_TRUE(m_testee.dataType() != UaNodeId(OpcUaType_Double, 0));
+	m_testee.setString(UaString("x"));
+	EXPECT_TRUE(m_testee.dataType() == UaNodeId(OpcUaType_String, 0));
+}
+
+TEST_F(UaVariantTest, testBooleanUasdkSpellings)
+{
+	m_testee.setBoolean(OpcUa_True);
+	OpcUa_Boolean out = OpcUa_False;
+	EXPECT_EQ(OpcUa_Good, m_testee.toBoolean(out));
+	EXPECT_TRUE(out);
+	UaBooleanArray arr;
+	arr.create(2);
+	arr[0] = OpcUa_True;
+	arr[1] = OpcUa_False;
+	m_testee.setBooleanArray(arr, OpcUa_False);
+	UaBooleanArray back;
+	EXPECT_EQ(OpcUa_Good, m_testee.toBooleanArray(back));
+	EXPECT_EQ(2u, back.size());
+}
+
+TEST_F(UaVariantTest, testToByteStringFromByteStringScalar)
+{
+	OpcUa_Byte raw[3] = {1, 2, 3};
+	UaByteString bs;
+	bs.setByteString(3, raw);
+	m_testee.setByteString(bs, false);
+	UaByteString out;
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, m_testee.toByteString(out).statusCode());
+	EXPECT_EQ(3, out.length());
+	EXPECT_EQ(2, out.data()[1]);
+}
+
+TEST_F(UaVariantTest, testToByteStringFromByteArray)
+{
+	UaByteArray arr;
+	arr.create(3);
+	arr[0] = 0xAA;
+	arr[1] = 0xBB;
+	arr[2] = 0xCC;
+	m_testee.setByteArray(arr, OpcUa_False);
+	UaByteString out;
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, m_testee.toByteString(out).statusCode());
+	EXPECT_EQ(3, out.length());
+	EXPECT_EQ(0xBB, out.data()[1]);
+}
+
+TEST_F(UaVariantTest, testToByteStringTypeMismatchReturnsBadWithoutThrowing)
+{
+	m_testee.setInt32(7);
+	UaByteString out;
+	UaStatus status;
+	EXPECT_NO_THROW(status = m_testee.toByteString(out));
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_BadTypeMismatch, status.statusCode());
+}
+
+TEST_F(UaVariantTest, testEmptyArrayRoundTripStaysArray)
+{
+	UaInt32Array empty;
+	m_testee.setInt32Array(empty, OpcUa_False);
+	EXPECT_FALSE(m_testee.isEmpty());
+	EXPECT_TRUE(m_testee.isArray());
+	EXPECT_EQ(0, m_testee.arraySize());
+	EXPECT_TRUE(m_testee.dataType() == UaNodeId(OpcUaType_Int32, 0));
+	UaInt32Array back;
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, m_testee.toInt32Array(back));
+	EXPECT_EQ(0u, back.size());
+	UaVariant copy(m_testee);
+	EXPECT_TRUE(copy.isArray());
+}
+
+TEST_F(UaVariantTest, testEmptyByteStringArrayRoundTrip)
+{
+	UaByteStringArray empty;
+	m_testee.setByteStringArray(empty, OpcUa_False);
+	EXPECT_TRUE(m_testee.isArray());
+	EXPECT_EQ(0, m_testee.arraySize());
+	UaByteStringArray back;
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, m_testee.toByteStringArray(back));
+	EXPECT_EQ(0u, back.size());
+}


### PR DESCRIPTION
Six UA-SDK API-fidelity gaps found by the backend-parity campaign, signatures verified against the UA-SDK 1.6.5 headers:

- **OPCUA-3400** `opcua_p_types.h` forwarding header
- **OPCUA-3401** `UaVariant::dataType()`
- **OPCUA-3402** `UaNodeId::operator!=`
- **OPCUA-3403** `UaVariant::toBoolean/setBoolean` (+Array) spellings
- **OPCUA-3404** `toByteString` returns `BadTypeMismatch` instead of throwing; converts Byte-array variants to ByteString (the quasar ArrayTools/CanOpen RPDO round-trip)
- **OPCUA-3405** empty 1-D arrays keep array-ness (`UA_EMPTY_ARRAY_SENTINEL` + element type instead of a null variant); `isScalarValue()` follows the stack's sentinel convention

**Verification**: gtest 36/36 (7 new regressions). Production-server proof: ScaOpcUa and CanOpenOpcUa built+run+probed in the docker parity harness on **unmodified compat** with all previous cell-local stand-ins removed — CanOpen was previously unbuildable without them. Cross-backend vs UA-SDK: functional histograms now identical (modulo the LogIt component node); prior bidirectional status flaps gone.