### PR TITLE
OPCUA-3406 + OPCUA-3407: property browse-name namespace and access level follow the server

### DIFF
--- a/include/uadatavariablecache.h
+++ b/include/uadatavariablecache.h
@@ -79,12 +79,14 @@ public:
 	virtual OpcUa_NodeClass nodeClass() const override { return OpcUa_NodeClass_Variable; }
 	virtual UaQualifiedName browseName() const override { return m_browseName; }
 	virtual UaDataValue value(Session*) { return UaDataValue(m_value, OpcUa_Good, UaDateTime::now(), UaDateTime::now()); }
+	OpcUa_Byte accessLevel() const { return m_accessLevel; }
 
 private:
 	const UaNodeId        m_nodeId;
 	const UaQualifiedName m_browseName;
 	const UaVariant       m_value;
 	const UaNodeId        m_typeDefinitionId;
+	const OpcUa_Byte      m_accessLevel;
 };
 
 #endif /* OPEN62541_COMPAT_INCLUDE_UADATAVARIABLECACHE_H_ */

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -324,6 +324,7 @@ UaStatus NodeManagerBase::addPropertyNodeAndReference(
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     attr.displayName = *displayName.impl();
     attr.dataType = to->typeDefinitionId().impl();
+    attr.accessLevel = to->accessLevel();
     UaVariant(*to->value(nullptr).value()).copyTo(&attr.value);
 
     LOG(Log::TRC) << "to=" << to->nodeId().toFullString().toUtf8() << " reftype=" << refType.toFullString().toUtf8();

--- a/src/uadatavariablecache.cpp
+++ b/src/uadatavariablecache.cpp
@@ -18,7 +18,7 @@ UaPropertyMethodArgument::UaPropertyMethodArgument  (
 			ArgumentType   argumentType):
 			m_nodeId(nodeId),
 			m_numberArguments( numberOfArguments ),
-			m_browseName(0, "args"),
+			m_browseName(nodeId.namespaceIndex(), "args"),
 			m_impl( new UA_Argument* [ numberOfArguments] ),
 			m_argumentType(argumentType)
 {
@@ -67,7 +67,7 @@ UaPropertyCache::UaPropertyCache (
 		OpcUa_Byte,
 		const UaString&) :
 				m_nodeId(nodeId),
-				m_browseName(0, name),
+				m_browseName(nodeId.namespaceIndex(), name),
 				m_value(defaultValue),
 				m_typeDefinitionId(defaultValue.type())
 {}

--- a/src/uadatavariablecache.cpp
+++ b/src/uadatavariablecache.cpp
@@ -64,10 +64,11 @@ UaPropertyCache::UaPropertyCache (
 		const UaString  &name,
 		const UaNodeId  &nodeId,
 		const UaVariant &defaultValue,
-		OpcUa_Byte,
+		OpcUa_Byte      accessLevel,
 		const UaString&) :
 				m_nodeId(nodeId),
 				m_browseName(nodeId.namespaceIndex(), name),
 				m_value(defaultValue),
-				m_typeDefinitionId(defaultValue.type())
+				m_typeDefinitionId(defaultValue.type()),
+				m_accessLevel(accessLevel)
 {}

--- a/test/src/uapropertycache_test.cpp
+++ b/test/src/uapropertycache_test.cpp
@@ -1,0 +1,39 @@
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
+ * uapropertycache_test.cpp
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gtest/gtest.h"
+#include <uadatavariablecache.h>
+
+TEST(UaPropertyCacheTest, browseNameNamespaceFollowsNodeId)
+{
+	UaPropertyCache property(
+			UaString("address"),
+			UaNodeId(UaString("elmb1.address"), 2),
+			UaVariant(UaString("42")),
+			0x1,
+			UaString("en_US"));
+	EXPECT_EQ(std::string("ns=2|address"), property.browseName().toFullString().toUtf8());
+
+	UaPropertyCache nsZeroProperty(
+			UaString("standardish"),
+			UaNodeId(static_cast<OpcUa_UInt32>(12345), 0),
+			UaVariant(static_cast<OpcUa_Int32>(1)),
+			0x1,
+			UaString("en_US"));
+	EXPECT_EQ(std::string("ns=0|standardish"), nsZeroProperty.browseName().toFullString().toUtf8());
+}

--- a/test/src/uapropertycache_test.cpp
+++ b/test/src/uapropertycache_test.cpp
@@ -37,3 +37,14 @@ TEST(UaPropertyCacheTest, browseNameNamespaceFollowsNodeId)
 			UaString("en_US"));
 	EXPECT_EQ(std::string("ns=0|standardish"), nsZeroProperty.browseName().toFullString().toUtf8());
 }
+
+TEST(UaPropertyCacheTest, accessLevelIsStored)
+{
+	UaPropertyCache property(
+			UaString("address"),
+			UaNodeId(UaString("elmb1.address"), 2),
+			UaVariant(UaString("42")),
+			UA_ACCESSLEVELMASK_READ,
+			UaString("en_US"));
+	EXPECT_EQ(UA_ACCESSLEVELMASK_READ, property.accessLevel());
+}


### PR DESCRIPTION
Two property-node fidelity fixes, verified against UA-SDK 1.6.5 behavior:

- **OPCUA-3406**: `UaPropertyCache`/`UaPropertyMethodArgument` hardcoded browse-name namespace 0; now derived from the node id (UA-SDK takes no namespace parameter and does the same). Method `InputArguments`/`OutputArguments` are unaffected — created ns0 by the stack itself on both backends (verified in live dumps).
- **OPCUA-3407**: `UaPropertyCache`'s accessLevel was discarded and properties were built from `UA_VariableAttributes_default` (exposing StatusWrite/TimestampWrite); now honored.

**Verification**: gtest 38/38 (new tests red→green). CanOpenOpcUa cross-backend comparison: browse-name mismatches 195→0; accesslevel diffs 207→12 where the remaining 12 are the stack-created method-argument properties (out of scope, see OPCUA-3407 notes). Address space now matches UA-SDK modulo the LogIt component node.