### PR TITLE
OPCUA-3408: UaNodeId string formats follow UA-SDK

### DIFF
--- a/src/uanodeid.cpp
+++ b/src/uanodeid.cpp
@@ -98,21 +98,46 @@ UaString UaNodeId::toString() const
     }
     else if (identifierType() == IdentifierType::OpcUa_IdentifierType_Numeric)
     {
-        std::string s = "(ns="+boost::lexical_cast<std::string>(namespaceIndex())+","+boost::lexical_cast<std::string>(identifierNumeric())+")";
-        return UaString(s.c_str());
+        return UaString(boost::lexical_cast<std::string>(identifierNumeric()).c_str());
     }
     return "identifier-type-unsupported";
 }
 
 UaString UaNodeId::toFullString() const
 {
-    if (identifierType() == IdentifierType::OpcUa_IdentifierType_String)
+    std::string s = "NS" + boost::lexical_cast<std::string>(namespaceIndex()) + "|";
+    switch (m_impl.identifierType)
     {
-        std::string s = "(ns="+boost::lexical_cast<std::string>(namespaceIndex())+","+UaString(identifierString()).toUtf8()+")";
-        return UaString(s.c_str());
+    case UA_NODEIDTYPE_NUMERIC:
+        s += "Numeric|" + boost::lexical_cast<std::string>(identifierNumeric());
+        break;
+    case UA_NODEIDTYPE_STRING:
+        s += "String|" + UaString(identifierString()).toUtf8();
+        break;
+    case UA_NODEIDTYPE_BYTESTRING:
+    {
+        s += "Opaque|0x";
+        char hex[3];
+        for (size_t i = 0; i < m_impl.identifier.byteString.length; ++i)
+        {
+            snprintf(hex, sizeof hex, "%02x", m_impl.identifier.byteString.data[i]);
+            s += hex;
+        }
+        break;
     }
-    else
-        return toString();
+    case UA_NODEIDTYPE_GUID:
+    {
+        char guid[40];
+        const UA_Guid& g = m_impl.identifier.guid;
+        snprintf(guid, sizeof guid, "Guid|%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+                g.data1, g.data2, g.data3,
+                g.data4[0], g.data4[1], g.data4[2], g.data4[3],
+                g.data4[4], g.data4[5], g.data4[6], g.data4[7]);
+        s += guid;
+        break;
+    }
+    }
+    return UaString(s.c_str());
 }
 
 void UaNodeId::copyTo( UaNodeId* other) const

--- a/test/src/uapropertycache_test.cpp
+++ b/test/src/uapropertycache_test.cpp
@@ -48,3 +48,19 @@ TEST(UaPropertyCacheTest, accessLevelIsStored)
 			UaString("en_US"));
 	EXPECT_EQ(UA_ACCESSLEVELMASK_READ, property.accessLevel());
 }
+
+TEST(UaNodeIdFormatTest, toFullStringMatchesUasdk)
+{
+	EXPECT_EQ(std::string("NS2|String|elmb1.address"),
+			UaNodeId(UaString("elmb1.address"), 2).toFullString().toUtf8());
+	EXPECT_EQ(std::string("NS0|Numeric|85"),
+			UaNodeId(static_cast<OpcUa_UInt32>(85), 0).toFullString().toUtf8());
+}
+
+TEST(UaNodeIdFormatTest, toStringIsIdentifierOnly)
+{
+	EXPECT_EQ(std::string("elmb1.address"),
+			UaNodeId(UaString("elmb1.address"), 2).toString().toUtf8());
+	EXPECT_EQ(std::string("85"),
+			UaNodeId(static_cast<OpcUa_UInt32>(85), 0).toString().toUtf8());
+}


### PR DESCRIPTION
`toFullString()` now produces the UA-SDK format (`NS2|String|elmb1.address`, `NS0|Numeric|85`, Guid/Opaque best-effort) — extracted verbatim from the UA-SDK 1.6.5 binaries — replacing the home-grown `(ns=2,...)` shape whose regex-hostile parentheses broke servers that build node-lookup patterns from it. `toString()` on numeric ids returns the bare identifier per the UA-SDK doc contract.

**Root-caused crash**: eltek's `DMains::getPhaseASNode` builds a `findAllByPattern` regex from `toFullString()`; under the old compat format the lookup returned nothing and an unguarded `[0]` segfaulted the server.

**Verification**: gtest 40/40 (exact-string format tests). jcop-eltek-o6 cell re-run with **pristine** eltek sources (previous cell-local patch removed): server runs, the crash path executes cleanly (`found [1] ... pattern [NS2|String|LabTestSystem.mains.phase1]`), and the cross-backend address-space comparison vs UA-SDK shows **zero attribute diffs**. Internal compat/quasar consumers of these strings are log-messages only.