### PR TITLE
OPCUA-3410: UA-SDK API surface package (hvsys-class servers) + UA-SDK utility headers

### DIFF
--- a/include/opcua_basedatavariabletype.h
+++ b/include/opcua_basedatavariabletype.h
@@ -33,7 +33,7 @@
 namespace OpcUa
 {
 
-class BaseDataVariableType: public UaNode
+class BaseDataVariableType: public UaVariable
 {
 public:
     BaseDataVariableType(

--- a/include/opcua_platformdefs.h
+++ b/include/opcua_platformdefs.h
@@ -20,6 +20,8 @@
 
 
 #include <stdint.h>
+#include <map>
+#include <string>
 
 typedef bool     OpcUa_Boolean;
 typedef uint8_t  OpcUa_Byte;

--- a/include/other.h
+++ b/include/other.h
@@ -48,7 +48,11 @@ class UaQualifiedName
 {
   public:
     UaQualifiedName(int ns, const UaString& name);
+    UaQualifiedName(const UaString& name, OpcUa_UInt16 nameSpaceIdx);
     UA_QualifiedName impl() const { return m_impl; }
+    OpcUa_UInt16 namespaceIndex() const { return m_impl.namespaceIndex; }
+    bool operator==(const UaQualifiedName& other) const
+    { return m_impl.namespaceIndex == other.m_impl.namespaceIndex && m_unqualifiedName == other.m_unqualifiedName; }
     UaString unqualifiedName() const { return m_unqualifiedName; }
     UaString toString() const;
     UaString toFullString() const;

--- a/include/srvtrace.h
+++ b/include/srvtrace.h
@@ -1,7 +1,4 @@
-/* © Copyright Piotr Nikiel, CERN, 2015.  All rights not expressly granted are reserved.
- *
- *  Created on: 15 Nov,  2015
- *      Author: Piotr Nikiel <piotr@nikiel.info>
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
  *
  *  This file is part of Quasar.
  *
@@ -18,23 +15,9 @@
  *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef OPEN62541_COMPAT_INCLUDE_SRVTRACE_H_
+#define OPEN62541_COMPAT_INCLUDE_SRVTRACE_H_
 
-#include <stdint.h>
-#include <map>
-#include <string>
+#include <opcua_platformdefs.h>
 
-typedef bool     OpcUa_Boolean;
-
-#define OpcUa_UInt32_Max 0xFFFFFFFFu
-typedef uint8_t  OpcUa_Byte;
-typedef int8_t   OpcUa_SByte;
-typedef uint16_t OpcUa_UInt16;
-typedef int16_t  OpcUa_Int16;
-typedef uint32_t OpcUa_UInt32;
-typedef int32_t  OpcUa_Int32;
-typedef uint64_t OpcUa_UInt64;
-typedef int64_t  OpcUa_Int64;
-typedef float    OpcUa_Float;
-typedef double   OpcUa_Double;
-
-class UaVariant;
+#endif /* OPEN62541_COMPAT_INCLUDE_SRVTRACE_H_ */

--- a/include/uabasenodes.h
+++ b/include/uabasenodes.h
@@ -27,6 +27,17 @@
 #include <uadatavalue.h>
 #include <session.h>
 
+const OpcUa_UInt32 Ua_AccessLevel_None         = 0x0;
+const OpcUa_UInt32 Ua_AccessLevel_CurrentRead  = 0x1;
+const OpcUa_UInt32 Ua_AccessLevel_CurrentWrite = 0x2;
+const OpcUa_UInt32 Ua_AccessLevel_HistoryRead  = 0x4;
+const OpcUa_UInt32 Ua_AccessLevel_HistoryWrite = 0x8;
+
+const OpcUa_UInt32 UaVariable_Value_None                    = 0x0;
+const OpcUa_UInt32 UaVariable_Value_Cache                   = 0x1;
+const OpcUa_UInt32 UaVariable_Value_CacheIsSource           = 0x2;
+const OpcUa_UInt32 UaVariable_Value_CacheIsUpdatedOnRequest = 0x4;
+
 class UaVariable: public UaNode
 {
 public:

--- a/include/uabasenodes.h
+++ b/include/uabasenodes.h
@@ -23,6 +23,19 @@
 #define OPEN62541_COMPAT_INCLUDE_UABASENODES_H_
 
 #include <uanode.h>
+#include <statuscode.h>
+#include <uadatavalue.h>
+#include <session.h>
+
+class UaVariable: public UaNode
+{
+public:
+    virtual UaDataValue value(Session* session) = 0;
+    virtual UaStatus setValue(
+            Session *session,
+            const UaDataValue& dataValue,
+            OpcUa_Boolean checkAccessLevel = OpcUa_True ) = 0;
+};
 
 class UaObject: public UaNode
 {

--- a/include/uadatavalue.h
+++ b/include/uadatavalue.h
@@ -15,8 +15,17 @@
 class UaDataValue
 {
   public:
+    UaDataValue();
     UaDataValue( const UaVariant& variant, OpcUa_StatusCode statusCode, const UaDateTime& sourceTime, const UaDateTime& serverTime );
     UaDataValue( const UaDataValue& other );
+
+    void setValue( UaVariant& value, OpcUa_Boolean detachValue, OpcUa_Boolean updateTimeStamps = OpcUa_False );
+    void setDataValue( UaVariant& value, OpcUa_Boolean detachValue, OpcUa_StatusCode statusCode, const UaDateTime& sourceTimestamp, const UaDateTime& serverTimestamp );
+    void setStatusCode( OpcUa_StatusCode statusCode );
+    void setSourceTimestamp( const UaDateTime& sourceTimestamp );
+    void setServerTimestamp( const UaDateTime& serverTimestamp );
+    UaDateTime sourceTimestamp() const { return UaDateTime(m_impl->sourceTimestamp); }
+    UaDateTime serverTimestamp() const { return UaDateTime(m_impl->serverTimestamp); }
     void operator=(const UaDataValue& other );
     bool operator==(const UaDataValue &other) const;
     bool operator!=(const UaDataValue &other) const;

--- a/include/uadatetime.h
+++ b/include/uadatetime.h
@@ -41,10 +41,17 @@ public:
 	UaString toString() const;
 	explicit operator UA_DateTime() const {return m_dateTime;}
 
+	static UaDateTime fromTime_t(time_t epochSeconds)
+	{ return UaDateTime(static_cast<UA_DateTime>(epochSeconds) * UA_DATETIME_SEC + UA_DATETIME_UNIX_EPOCH); }
+	time_t toTime_t() const
+	{ return static_cast<time_t>((m_dateTime - UA_DATETIME_UNIX_EPOCH) / UA_DATETIME_SEC); }
+
 private:
 
 
 	UA_DateTime m_dateTime; // (64bit signed int ) num of 100 nanosec intervals since windows epoch (1601-01-01T00:00:00)
 };
+
+typedef UA_DateTime OpcUa_DateTime;
 
 #endif // __UADATETIME_H_

--- a/include/uanode.h
+++ b/include/uanode.h
@@ -53,6 +53,15 @@ public:
 
     void addReferencedTarget( UaNode* targetNode, UaNodeId referenceTypeId ) { m_referenceTargets.push_back( ReferencedTarget(targetNode, referenceTypeId));  }
     const std::list<ReferencedTarget>* referencedTargets() const { return &m_referenceTargets; }
+
+    virtual UaNode* getUaReferenceLists() const { return const_cast<UaNode*>(this); }
+    UaNode* getTargetNodeByBrowseName( const UaQualifiedName& browseName ) const
+    {
+        for (const ReferencedTarget& candidate : m_referenceTargets)
+            if (candidate.target && candidate.target->browseName() == browseName)
+                return candidate.target;
+        return nullptr;
+    }
 private:    
     std::list<ReferencedTarget> m_referenceTargets;
 

--- a/include/uaobjecttypes.h
+++ b/include/uaobjecttypes.h
@@ -1,7 +1,4 @@
-/* © Copyright Piotr Nikiel, CERN, 2015.  All rights not expressly granted are reserved.
- *
- *  Created on: 15 Nov,  2015
- *      Author: Piotr Nikiel <piotr@nikiel.info>
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
  *
  *  This file is part of Quasar.
  *
@@ -18,23 +15,11 @@
  *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef OPEN62541_COMPAT_INCLUDE_UAOBJECTTYPES_H_
+#define OPEN62541_COMPAT_INCLUDE_UAOBJECTTYPES_H_
 
-#include <stdint.h>
-#include <map>
-#include <string>
+#include <uabasenodes.h>
+#include <other.h>
+#include <list>
 
-typedef bool     OpcUa_Boolean;
-
-#define OpcUa_UInt32_Max 0xFFFFFFFFu
-typedef uint8_t  OpcUa_Byte;
-typedef int8_t   OpcUa_SByte;
-typedef uint16_t OpcUa_UInt16;
-typedef int16_t  OpcUa_Int16;
-typedef uint32_t OpcUa_UInt32;
-typedef int32_t  OpcUa_Int32;
-typedef uint64_t OpcUa_UInt64;
-typedef int64_t  OpcUa_Int64;
-typedef float    OpcUa_Float;
-typedef double   OpcUa_Double;
-
-class UaVariant;
+#endif /* OPEN62541_COMPAT_INCLUDE_UAOBJECTTYPES_H_ */

--- a/include/uasemaphore.h
+++ b/include/uasemaphore.h
@@ -1,0 +1,68 @@
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPEN62541_COMPAT_INCLUDE_UASEMAPHORE_H_
+#define OPEN62541_COMPAT_INCLUDE_UASEMAPHORE_H_
+
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
+#include <statuscode.h>
+
+class UaSemaphore
+{
+public:
+    UaSemaphore( OpcUa_UInt32 initialValue, OpcUa_UInt32 maxRange ):
+        m_count(initialValue),
+        m_maxRange(maxRange)
+    {}
+
+    OpcUa_StatusCode wait()
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_condition.wait(lock, [this]{ return m_count > 0; });
+        --m_count;
+        return OpcUa_Good;
+    }
+
+    OpcUa_StatusCode timedWait( OpcUa_UInt32 msecTimeout )
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        if (!m_condition.wait_for(lock, std::chrono::milliseconds(msecTimeout), [this]{ return m_count > 0; }))
+            return OpcUa_BadTimeout;
+        --m_count;
+        return OpcUa_Good;
+    }
+
+    OpcUa_StatusCode post( OpcUa_UInt32 releaseCount )
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_count + releaseCount > m_maxRange)
+            return OpcUa_BadInvalidArgument;
+        m_count += releaseCount;
+        m_condition.notify_all();
+        return OpcUa_Good;
+    }
+
+private:
+    std::mutex m_mutex;
+    std::condition_variable m_condition;
+    OpcUa_UInt32 m_count;
+    OpcUa_UInt32 m_maxRange;
+};
+
+#endif /* OPEN62541_COMPAT_INCLUDE_UASEMAPHORE_H_ */

--- a/include/uastring.h
+++ b/include/uastring.h
@@ -52,9 +52,10 @@ public:
     ~UaString ();
  
     UaString operator+(const UaString& other);
-    bool operator==(const UaString& other);
+    bool operator==(const UaString& other) const;
+    bool operator!=(const UaString& other) const { return !(*this == other); }
 
-    std::string toUtf8() const;
+    const char* toUtf8() const;
 
     const UA_String * impl() const{ return m_impl; }
 
@@ -67,6 +68,7 @@ public:
 
 private:
     UA_String * m_impl;
+    mutable std::string m_utf8;
 };
 
 #endif // __UASTRING_H_

--- a/include/uathread.h
+++ b/include/uathread.h
@@ -1,0 +1,73 @@
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPEN62541_COMPAT_INCLUDE_UATHREAD_H_
+#define OPEN62541_COMPAT_INCLUDE_UATHREAD_H_
+
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <opcua_platformdefs.h>
+
+class UaThread
+{
+public:
+    UaThread(): m_running(false), m_finished(false) {}
+    virtual ~UaThread()
+    {
+        if (m_thread.joinable())
+            m_thread.join();
+    }
+
+    virtual void start()
+    {
+        m_running = true;
+        m_thread = std::thread([this]{
+            this->run();
+            m_running = false;
+            m_finished = true;
+        });
+    }
+
+    OpcUa_Boolean wait( OpcUa_UInt32 /*time*/ = OpcUa_UInt32_Max )
+    {
+        if (m_thread.joinable())
+            m_thread.join();
+        return OpcUa_True;
+    }
+
+    OpcUa_Boolean running() const { return m_running; }
+    OpcUa_Boolean finished() const { return m_finished; }
+
+    static OpcUa_UInt32 currentThread()
+    { return static_cast<OpcUa_UInt32>(std::hash<std::thread::id>()(std::this_thread::get_id())); }
+
+    static void sleep( OpcUa_UInt32 secs )  { std::this_thread::sleep_for(std::chrono::seconds(secs)); }
+    static void msleep( OpcUa_UInt32 msecs ){ std::this_thread::sleep_for(std::chrono::milliseconds(msecs)); }
+    static void usleep( OpcUa_UInt32 usecs ){ std::this_thread::sleep_for(std::chrono::microseconds(usecs)); }
+
+protected:
+    virtual void run() = 0;
+
+private:
+    std::thread m_thread;
+    std::atomic_bool m_running;
+    std::atomic_bool m_finished;
+};
+
+#endif /* OPEN62541_COMPAT_INCLUDE_UATHREAD_H_ */

--- a/include/uavariant.h
+++ b/include/uavariant.h
@@ -55,6 +55,7 @@ enum OpcUaType
   };
 
 typedef OpcUaType OpcUa_BuiltInType;
+typedef OpcUaType _OpcUa_BuiltInType;
 
 class UaVariant
 {

--- a/include/uavariant.h
+++ b/include/uavariant.h
@@ -54,6 +54,8 @@ enum OpcUaType
     // support for remaining types, i.e. nodeid or statuscode also still missing
   };
 
+typedef OpcUaType OpcUa_BuiltInType;
+
 class UaVariant
 {
  public:
@@ -76,6 +78,7 @@ class UaVariant
 
   ~UaVariant();
   OpcUaType type() const;
+  OpcUa_StatusCode changeType( OpcUaType targetType, OpcUa_Boolean toArray );
   UaNodeId dataType() const { return UaNodeId(static_cast<OpcUa_UInt32>(type()), 0); }
 
   // setters

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -213,8 +213,6 @@ UaStatus NodeManagerBase::addObjectNodeAndReference(
         UaNode* to,
         const UaNodeId& refType)
 {
-    if (parent && to)
-        parent->addReferencedTarget(to, refType);
     UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UA_ObjectAttributes objectAttributes;
     UA_ObjectAttributes_init( &objectAttributes );
@@ -250,8 +248,6 @@ UaStatus NodeManagerBase::addDataVariableNodeAndReference(
 		OpcUa::BaseDataVariableType* variable,
         const UaNodeId& refType)
 {
-    if (parent && variable)
-        parent->addReferencedTarget(variable, refType);
 	UaLocalizedText displayName( "en_US", variable->browseName().unqualifiedName().toUtf8());
     UA_DataSource dateDataSource
     {
@@ -324,8 +320,6 @@ UaStatus NodeManagerBase::addPropertyNodeAndReference(
 	UaPropertyCache* to,
     const UaNodeId& refType)
 {
-    if (parent && to)
-        parent->addReferencedTarget(to, refType);
 	UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     attr.displayName = *displayName.impl();
@@ -357,8 +351,6 @@ UaStatus NodeManagerBase::addMethodNodeAndReference(
     UaNode* to,
     const UaNodeId& refType)
 {
-    if (parent && to)
-        parent->addReferencedTarget(to, refType);
     UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UA_MethodAttributes attr;
     UA_MethodAttributes_init(&attr);

--- a/src/nodemanagerbase.cpp
+++ b/src/nodemanagerbase.cpp
@@ -213,7 +213,9 @@ UaStatus NodeManagerBase::addObjectNodeAndReference(
         UaNode* to,
         const UaNodeId& refType)
 {
-    UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8().c_str());
+    if (parent && to)
+        parent->addReferencedTarget(to, refType);
+    UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UA_ObjectAttributes objectAttributes;
     UA_ObjectAttributes_init( &objectAttributes );
     objectAttributes.description = *emptyDescription.impl();
@@ -248,7 +250,9 @@ UaStatus NodeManagerBase::addDataVariableNodeAndReference(
 		OpcUa::BaseDataVariableType* variable,
         const UaNodeId& refType)
 {
-	UaLocalizedText displayName( "en_US", variable->browseName().unqualifiedName().toUtf8().c_str());
+    if (parent && variable)
+        parent->addReferencedTarget(variable, refType);
+	UaLocalizedText displayName( "en_US", variable->browseName().unqualifiedName().toUtf8());
     UA_DataSource dateDataSource
     {
         unifiedRead,
@@ -312,7 +316,7 @@ UaStatus NodeManagerBase::addVariableNodeAndReference(
     else
     	OPEN62541_COMPAT_LOG_AND_THROW(
     			std::logic_error,
-				"Can't add this variable: no obvious handler in existing open62541 interface, do not know what to do! Requested variable address is " + to->nodeId().toString().toUtf8());
+				std::string("Can't add this variable: no obvious handler in existing open62541 interface, do not know what to do! Requested variable address is ") + to->nodeId().toString().toUtf8());
 }
 
 UaStatus NodeManagerBase::addPropertyNodeAndReference(
@@ -320,7 +324,9 @@ UaStatus NodeManagerBase::addPropertyNodeAndReference(
 	UaPropertyCache* to,
     const UaNodeId& refType)
 {
-	UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8().c_str());
+    if (parent && to)
+        parent->addReferencedTarget(to, refType);
+	UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UA_VariableAttributes attr = UA_VariableAttributes_default;
     attr.displayName = *displayName.impl();
     attr.dataType = to->typeDefinitionId().impl();
@@ -342,7 +348,7 @@ UaStatus NodeManagerBase::addPropertyNodeAndReference(
 	if (!s.isGood())
 		OPEN62541_COMPAT_LOG_AND_THROW(
 				std::runtime_error,
-				"failed to add property " + to->nodeId().toString().toUtf8() + " because: " + s.toString().toUtf8());
+				std::string("failed to add property ") + to->nodeId().toString().toUtf8() + " because: " + s.toString().toUtf8());
 	return s;
 }
 
@@ -351,7 +357,9 @@ UaStatus NodeManagerBase::addMethodNodeAndReference(
     UaNode* to,
     const UaNodeId& refType)
 {
-    UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8().c_str());
+    if (parent && to)
+        parent->addReferencedTarget(to, refType);
+    UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UA_MethodAttributes attr;
     UA_MethodAttributes_init(&attr);
     attr.executable = true;
@@ -439,7 +447,7 @@ UaStatus NodeManagerBase::addNodeAndReference(
     UaNode* to,
     const UaNodeId& refType)
 {
-    UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8().c_str());
+    UaLocalizedText displayName( "en_US", to->browseName().unqualifiedName().toUtf8());
     UaLocalizedText dummyDescription( "en_US", "DummyDescription" );
     switch( to->nodeClass() )
     {

--- a/src/open62541_compat.cpp
+++ b/src/open62541_compat.cpp
@@ -33,6 +33,13 @@ UaQualifiedName::UaQualifiedName(int ns, const UaString& name):
     m_impl.namespaceIndex = ns;
 }
 
+UaQualifiedName::UaQualifiedName(const UaString& name, OpcUa_UInt16 nameSpaceIdx):
+    m_unqualifiedName( name )
+{
+    m_impl.name = *m_unqualifiedName.impl();
+    m_impl.namespaceIndex = nameSpaceIdx;
+}
+
 UaString  UaQualifiedName::toString() const
 {
     return UaString(m_impl.name);

--- a/src/uabytestring.cpp
+++ b/src/uabytestring.cpp
@@ -26,7 +26,7 @@ UaByteString::UaByteString( const UA_ByteString& other):
 {
     UaStatus status = UA_ByteString_copy(&other, m_impl);
     if (!status.isGood())
-    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_ByteString_copy failed: " + status.toString().toUtf8());
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, std::string("UA_ByteString_copy failed: ") + status.toString().toUtf8());
 }
 
 UaByteString::UaByteString( const int length, const OpcUa_Byte* data):
@@ -93,7 +93,7 @@ void UaByteString::copyTo(UaByteString* other) const
     other->release();
     UaStatus status = UA_ByteString_copy(m_impl, other->m_impl);
     if (!status.isGood())
-    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "UA_ByteString_copy failed with: " + status.toString().toUtf8());
+    	OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, std::string("UA_ByteString_copy failed with: ") + status.toString().toUtf8());
 }
 
 void UaByteString::release()

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -105,12 +105,12 @@ UaStatus UaSession::connect(
 
     // TODO @Piotr note that many possibly important settings are not carried
     // from UA-SDK API to open6! At the moment, only timeout is.
-    LOG(Log::DBG) << "Will connect to OPC-UA endpoint [" << endpoint.toUtf8().c_str() << "], " <<
+    LOG(Log::DBG) << "Will connect to OPC-UA endpoint [" << endpoint.toUtf8() << "], " <<
     		"serviceCallTimeout=[" << clientConfig->timeout << "] ms, " <<
 			"requestedSessionTimeout=[" << clientConfig->requestedSessionTimeout << "] ms, " <<
 			"secureChannelLifeTime=[" << clientConfig->secureChannelLifeTime << "] ms, " <<
             "connectivityCheckInterval=[" << clientConfig->connectivityCheckInterval << "] ms";
-    UaStatus status = UA_Client_connect(m_client, endpoint.toUtf8().c_str());
+    UaStatus status = UA_Client_connect(m_client, endpoint.toUtf8());
 
     if(! status.isGood())
     {

--- a/src/uadatavalue.cpp
+++ b/src/uadatavalue.cpp
@@ -42,6 +42,70 @@ UaDataValue::UaDataValue( const UaVariant& variant, OpcUa_StatusCode statusCode,
 
 }
 
+UaDataValue::UaDataValue()
+{
+    m_impl = UA_DataValue_new ();
+    if (!m_impl)
+    	OPEN62541_COMPAT_LOG_AND_THROW(
+    			std::runtime_error,
+				"UA_DataValue_new returned null ptr" );
+}
+
+void UaDataValue::setValue( UaVariant& value, OpcUa_Boolean detachValue, OpcUa_Boolean updateTimeStamps )
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+    UA_Variant_clear( &m_impl->value );
+    UA_Variant_copy( value.impl(), &m_impl->value );
+    m_impl->hasValue = 1;
+    if (detachValue != OpcUa_False)
+        value.clear();
+    if (updateTimeStamps != OpcUa_False)
+    {
+        UA_DateTime now = UA_DateTime_now();
+        m_impl->sourceTimestamp = now;
+        m_impl->hasSourceTimestamp = UA_TRUE;
+        m_impl->serverTimestamp = now;
+        m_impl->hasServerTimestamp = UA_TRUE;
+    }
+}
+
+void UaDataValue::setDataValue( UaVariant& value, OpcUa_Boolean detachValue, OpcUa_StatusCode statusCode, const UaDateTime& sourceTimestamp, const UaDateTime& serverTimestamp )
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+    UA_Variant_clear( &m_impl->value );
+    UA_Variant_copy( value.impl(), &m_impl->value );
+    m_impl->hasValue = 1;
+    if (detachValue != OpcUa_False)
+        value.clear();
+    m_impl->status = statusCode;
+    m_impl->hasStatus = 1;
+    m_impl->sourceTimestamp = static_cast<UA_DateTime>(sourceTimestamp);
+    m_impl->hasSourceTimestamp = UA_TRUE;
+    m_impl->serverTimestamp = static_cast<UA_DateTime>(serverTimestamp);
+    m_impl->hasServerTimestamp = UA_TRUE;
+}
+
+void UaDataValue::setStatusCode( OpcUa_StatusCode statusCode )
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+    m_impl->status = statusCode;
+    m_impl->hasStatus = 1;
+}
+
+void UaDataValue::setSourceTimestamp( const UaDateTime& sourceTimestamp )
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+    m_impl->sourceTimestamp = static_cast<UA_DateTime>(sourceTimestamp);
+    m_impl->hasSourceTimestamp = UA_TRUE;
+}
+
+void UaDataValue::setServerTimestamp( const UaDateTime& serverTimestamp )
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+    m_impl->serverTimestamp = static_cast<UA_DateTime>(serverTimestamp);
+    m_impl->hasServerTimestamp = UA_TRUE;
+}
+
 UaDataValue::UaDataValue( const UaDataValue& other )
 {
     m_impl = UA_DataValue_new ();

--- a/src/uanodeid.cpp
+++ b/src/uanodeid.cpp
@@ -112,7 +112,8 @@ UaString UaNodeId::toFullString() const
         s += "Numeric|" + boost::lexical_cast<std::string>(identifierNumeric());
         break;
     case UA_NODEIDTYPE_STRING:
-        s += "String|" + UaString(identifierString()).toUtf8();
+        s += "String|";
+        s += UaString(identifierString()).toUtf8();
         break;
     case UA_NODEIDTYPE_BYTESTRING:
     {

--- a/src/uaserver.cpp
+++ b/src/uaserver.cpp
@@ -77,7 +77,7 @@ void UaServer::start()
     m_asyncOperations->setServing();
     UA_StatusCode status = UA_Server_run_startup(m_server);
     if (status != UA_STATUSCODE_GOOD)
-        throw std::runtime_error("UA_Server_run_startup returned not-good, server can't start. Error was:"+
+        throw std::runtime_error(std::string("UA_Server_run_startup returned not-good, server can't start. Error was:")+
                 UaStatus(status).toString().toUtf8());
     else
         LOG(Log::INF) <<

--- a/src/uastring.cpp
+++ b/src/uastring.cpp
@@ -78,7 +78,7 @@ UaString::~UaString ()
 
 UaString UaString::operator+(const UaString& other)
 {
-    std::string concatenated = this->toUtf8() + other.toUtf8();
+    std::string concatenated = std::string(this->toUtf8()) + other.toUtf8();
     return UaString( concatenated.c_str() );
 }
 
@@ -108,9 +108,10 @@ const UaString& UaString::operator=(const UA_String& other)
     return *this;
 }
 
-std::string UaString::toUtf8() const
+const char* UaString::toUtf8() const
 {
-  return std::string( reinterpret_cast<const char*>(m_impl->data), m_impl->length );
+  m_utf8.assign( reinterpret_cast<const char*>(m_impl->data), m_impl->length );
+  return m_utf8.c_str();
 }
 
 /** Note(Piotr): this is not real detachment.
@@ -122,7 +123,7 @@ void UaString::detach(UaString* out)
     *out = *this;
 }
 
-bool UaString::operator==(const UaString& other)
+bool UaString::operator==(const UaString& other) const
 {
     return UA_String_equal(this->m_impl, other.m_impl);
 }

--- a/src/uavariant.cpp
+++ b/src/uavariant.cpp
@@ -161,6 +161,32 @@ UaVariant::~UaVariant()
     m_impl = 0;
 }
 
+OpcUa_StatusCode UaVariant::changeType( OpcUaType targetType, OpcUa_Boolean toArray )
+{
+    if (toArray != OpcUa_False)
+        return OpcUa_BadNotSupported;
+    if (type() == targetType)
+        return OpcUa_Good;
+    switch (targetType)
+    {
+    case OpcUaType_Boolean: { OpcUa_Boolean v; UaStatus s = toBool(v);   if (!s.isGood()) return s.statusCode(); setBool(v);   break; }
+    case OpcUaType_SByte:   { OpcUa_SByte v;   UaStatus s = toSByte(v);  if (!s.isGood()) return s.statusCode(); setSByte(v);  break; }
+    case OpcUaType_Byte:    { OpcUa_Byte v;    UaStatus s = toByte(v);   if (!s.isGood()) return s.statusCode(); setByte(v);   break; }
+    case OpcUaType_Int16:   { OpcUa_Int16 v;   UaStatus s = toInt16(v);  if (!s.isGood()) return s.statusCode(); setInt16(v);  break; }
+    case OpcUaType_UInt16:  { OpcUa_UInt16 v;  UaStatus s = toUInt16(v); if (!s.isGood()) return s.statusCode(); setUInt16(v); break; }
+    case OpcUaType_Int32:   { OpcUa_Int32 v;   UaStatus s = toInt32(v);  if (!s.isGood()) return s.statusCode(); setInt32(v);  break; }
+    case OpcUaType_UInt32:  { OpcUa_UInt32 v;  UaStatus s = toUInt32(v); if (!s.isGood()) return s.statusCode(); setUInt32(v); break; }
+    case OpcUaType_Int64:   { OpcUa_Int64 v;   UaStatus s = toInt64(v);  if (!s.isGood()) return s.statusCode(); setInt64(v);  break; }
+    case OpcUaType_UInt64:  { OpcUa_UInt64 v;  UaStatus s = toUInt64(v); if (!s.isGood()) return s.statusCode(); setUInt64(v); break; }
+    case OpcUaType_Float:   { OpcUa_Float v;   UaStatus s = toFloat(v);  if (!s.isGood()) return s.statusCode(); setFloat(v);  break; }
+    case OpcUaType_Double:  { OpcUa_Double v;  UaStatus s = toDouble(v); if (!s.isGood()) return s.statusCode(); setDouble(v); break; }
+    case OpcUaType_String:  { setString(toString()); break; }
+    default:
+        return OpcUa_BadNotSupported;
+    }
+    return OpcUa_Good;
+}
+
 OpcUaType UaVariant::type() const
 {
     if (!m_impl->data)
@@ -402,7 +428,7 @@ void UaVariant::set1DArrayComplexTypes(
     {
         UaStatus status = copyFunction( input[i].impl(), &array[i] );
         if (!status.isGood())
-            OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, "copy function failed: "+status.toString().toUtf8());
+            OPEN62541_COMPAT_LOG_AND_THROW(std::runtime_error, std::string("copy function failed: ")+status.toString().toUtf8());
     }
     UA_Variant_setArray( m_impl, array, input.size(), dataType);
 }

--- a/test/src/uaqualifiedname_test.cpp
+++ b/test/src/uaqualifiedname_test.cpp
@@ -13,11 +13,11 @@
 TEST(UaQualifiedNameTest, testToString)
 {
     UaQualifiedName testee(2, "a.b.c");
-    EXPECT_EQ("a.b.c", testee.toString().toUtf8());
+    EXPECT_STREQ("a.b.c", testee.toString().toUtf8());
 }
 
 TEST(UaQualifiedNameTest, testToFullString)
 {
     UaQualifiedName testee(2, "a.b.c");
-    EXPECT_EQ("ns=2|a.b.c", testee.toFullString().toUtf8());
+    EXPECT_STREQ("ns=2|a.b.c", testee.toFullString().toUtf8());
 }

--- a/test/src/uasdk_surface_test.cpp
+++ b/test/src/uasdk_surface_test.cpp
@@ -1,0 +1,129 @@
+/* © Copyright Paris Moschovakos, CERN, 2026.  All rights not expressly granted are reserved.
+ * uasdk_surface_test.cpp
+ *
+ *  This file is part of Quasar.
+ *
+ *  Quasar is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public Licence as published by
+ *  the Free Software Foundation, either version 3 of the Licence.
+ *
+ *  Quasar is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public Licence for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with Quasar.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+#include "gtest/gtest.h"
+#include <uavariant.h>
+#include <uadatavalue.h>
+#include <uadatetime.h>
+#include <uadatavariablecache.h>
+#include <opcua_basedatavariabletype.h>
+
+TEST(UasdkSurfaceTest, changeTypeConvertsScalars)
+{
+	UaVariant v;
+	v.setUInt32(1);
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, v.changeType(OpcUaType_Boolean, OpcUa_False));
+	OpcUa_Boolean b = OpcUa_False;
+	v.toBool(b);
+	EXPECT_TRUE(b);
+
+	v.setInt32(-7);
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, v.changeType(OpcUaType_Float, OpcUa_False));
+	OpcUa_Float f = 0;
+	EXPECT_EQ(OpcUa_Good, v.toFloat(f).statusCode());
+	EXPECT_FLOAT_EQ(-7.0f, f);
+
+	v.setDouble(3.5);
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, v.changeType(OpcUaType_String, OpcUa_False));
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_BadNotSupported, v.changeType(OpcUaType_Int32, OpcUa_True));
+}
+
+TEST(UasdkSurfaceTest, dataValueDefaultCtorAndSetters)
+{
+	UaDataValue dv;
+	UaVariant value;
+	value.setInt16(42);
+	dv.setValue(value, OpcUa_False);
+	dv.setStatusCode(OpcUa_BadInternalError);
+	UaDateTime stamp = UaDateTime::fromTime_t(1765000000);
+	dv.setSourceTimestamp(stamp);
+	dv.setServerTimestamp(stamp);
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_BadInternalError, dv.statusCode());
+	EXPECT_EQ(1765000000, dv.sourceTimestamp().toTime_t());
+	OpcUa_Int16 out = 0;
+	UaVariant(*dv.value()).toInt16(out);
+	EXPECT_EQ(42, out);
+
+	UaDataValue dv2;
+	UaVariant value2;
+	value2.setFloat(1.5f);
+	dv2.setDataValue(value2, OpcUa_False, OpcUa_Good, stamp, stamp);
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, dv2.statusCode());
+	EXPECT_EQ(1765000000, dv2.serverTimestamp().toTime_t());
+}
+
+TEST(UasdkSurfaceTest, dateTimeTimeTRoundTrip)
+{
+	time_t epoch = 1700000123;
+	EXPECT_EQ(epoch, UaDateTime::fromTime_t(epoch).toTime_t());
+}
+
+TEST(UasdkSurfaceTest, qualifiedNameUasdkCtorAndEquality)
+{
+	UaQualifiedName uasdkOrder(UaString("address"), 2);
+	EXPECT_EQ(2, uasdkOrder.namespaceIndex());
+	EXPECT_TRUE(uasdkOrder == UaQualifiedName(2, UaString("address")));
+	EXPECT_FALSE(uasdkOrder == UaQualifiedName(0, UaString("address")));
+	EXPECT_FALSE(uasdkOrder == UaQualifiedName(2, UaString("other")));
+}
+
+TEST(UasdkSurfaceTest, stringUtf8IsCStringAndBangEquals)
+{
+	UaString s("hello");
+	EXPECT_EQ(0, strcmp(s.toUtf8(), "hello"));
+	EXPECT_TRUE(s != UaString("world"));
+	EXPECT_FALSE(s != UaString("hello"));
+	UaString joined = s + UaString(" there");
+	EXPECT_EQ(0, strcmp(joined.toUtf8(), "hello there"));
+}
+
+TEST(UasdkSurfaceTest, referenceListsWalkByBrowseName)
+{
+	UaPropertyCache parent(UaString("parent"), UaNodeId(UaString("p"), 2), UaVariant(OpcUa_UInt32(1)), 0x1, UaString("en_US"));
+	UaPropertyCache childA(UaString("alpha"), UaNodeId(UaString("p.alpha"), 2), UaVariant(OpcUa_UInt32(2)), 0x1, UaString("en_US"));
+	UaPropertyCache childB(UaString("beta"), UaNodeId(UaString("p.beta"), 2), UaVariant(OpcUa_UInt32(3)), 0x1, UaString("en_US"));
+	parent.addReferencedTarget(&childA, UaNodeId(47, 0));
+	parent.addReferencedTarget(&childB, UaNodeId(47, 0));
+
+	UaReferenceLists* lists = parent.getUaReferenceLists();
+	ASSERT_NE(nullptr, lists);
+	UaNode* hit = lists->getTargetNodeByBrowseName(UaQualifiedName(UaString("beta"), 2));
+	ASSERT_NE(nullptr, hit);
+	EXPECT_TRUE(hit->nodeId() == UaNodeId(UaString("p.beta"), 2));
+	EXPECT_EQ(nullptr, lists->getTargetNodeByBrowseName(UaQualifiedName(UaString("gamma"), 2)));
+	EXPECT_EQ(nullptr, lists->getTargetNodeByBrowseName(UaQualifiedName(UaString("beta"), 0)));
+}
+
+TEST(UasdkSurfaceTest, uaVariableDowncastAndSetValue)
+{
+	OpcUa::BaseDataVariableType variable(
+			UaNodeId(UaString("var1"), 2),
+			UaString("var1"),
+			2,
+			UaVariant(OpcUa_UInt32(0)),
+			UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE,
+			nullptr);
+	UaNode* node = &variable;
+	UaVariable* asVariable = (UaVariable*)node;
+	UaDataValue dv(UaVariant(OpcUa_UInt32(123)), OpcUa_Good, UaDateTime::now(), UaDateTime::now());
+	EXPECT_EQ(OpcUa_Good, asVariable->setValue(nullptr, dv, OpcUa_False).statusCode());
+	OpcUa_UInt32 out = 0;
+	UaVariant(*asVariable->value(nullptr).value()).toUInt32(out);
+	EXPECT_EQ(123u, out);
+}

--- a/test/src/uasdk_surface_test.cpp
+++ b/test/src/uasdk_surface_test.cpp
@@ -127,3 +127,37 @@ TEST(UasdkSurfaceTest, uaVariableDowncastAndSetValue)
 	UaVariant(*asVariable->value(nullptr).value()).toUInt32(out);
 	EXPECT_EQ(123u, out);
 }
+
+#include <uathread.h>
+#include <uasemaphore.h>
+#include <uaobjecttypes.h>
+#include <srvtrace.h>
+
+namespace
+{
+class CountingThread: public UaThread
+{
+public:
+	std::atomic_int counter{0};
+protected:
+	void run() override { ++counter; }
+};
+}
+
+TEST(UasdkSurfaceTest, threadRunsAndJoins)
+{
+	CountingThread t;
+	t.start();
+	EXPECT_TRUE(t.wait());
+	EXPECT_EQ(1, t.counter);
+	EXPECT_TRUE(t.finished());
+}
+
+TEST(UasdkSurfaceTest, semaphoreWaitPostAndTimeout)
+{
+	UaSemaphore sem(0, 1);
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_BadTimeout, sem.timedWait(20));
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, sem.post(1));
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_Good, sem.wait());
+	EXPECT_EQ((OpcUa_StatusCode)OpcUa_BadTimeout, sem.timedWait(20));
+}

--- a/test/src/uavariant_test.cpp
+++ b/test/src/uavariant_test.cpp
@@ -50,7 +50,7 @@ TEST_F(UaVariantTest, testConvertToSameInternalType)
 	EXPECT_EQ(uint64Value, uint64Result);
 
 	m_testee.setString(UaString("abcde"));
-	EXPECT_EQ("abcde", m_testee.toString().toUtf8());
+	EXPECT_STREQ("abcde", m_testee.toString().toUtf8());
 }
 
 TEST_F(UaVariantTest, testConvertFromBoolean)


### PR DESCRIPTION
The widest remaining UA-SDK fidelity package, found by the parity campaign on OpcUaHvSys ([OPCUA-3410](https://its.cern.ch/jira/browse/OPCUA-3410)) — all signatures verified against UA-SDK 1.6.5:

- `UaString::toUtf8()` → **`const char*`** (UA-SDK signature; cached NUL-terminated storage) + `operator!=`. Ecosystem survey: zero breaking uses in quasar; compat's own 7 `.c_str()` sites adjusted; tests migrated to `EXPECT_STREQ`.
- `UaQualifiedName(name, namespaceIndex)` ctor + `namespaceIndex()` + `operator==`
- `UaNode::getUaReferenceLists()` + `getTargetNodeByBrowseName()` over the reference targets quasar's ASNodeManager registers
- `UaVariable` abstract base; `BaseDataVariableType` derives from it
- `UaVariant::changeType` (scalar conversions) + `OpcUa_BuiltInType`/`_OpcUa_BuiltInType` aliases
- `UaDataValue` default ctor + `setValue`/`setDataValue`/`setStatusCode`/`set{Source,Server}Timestamp` + timestamp getters
- `UaDateTime::toTime_t`/`fromTime_t` + `OpcUa_DateTime`
- **New headers**: `uathread.h` (std::thread-backed UaThread), `uasemaphore.h`, `uaobjecttypes.h`, `srvtrace.h` (used by hvsys, ftksbc, genericsnmp, purity)
- `Ua_AccessLevel_*`, `UaVariable_Value_*` constants; `<map>/<string>` transitively via platform defs; `OpcUa_UInt32_Max`

Deliberately **not** emulated: raw `OpcUa_Variant` union access (`.Value.*`) — structurally incompatible with `UA_Variant`; the portable 3-line `UaVariant`-accessor form is the recommendation for the one server using it.

**Verification**: gtest 49/49 (new surface suite incl. thread/semaphore/reference-walk/downcast). OpcUaHvSys — previously unbuildable under o6 — builds, runs and probes in the parity harness; cross-backend vs UA-SDK: **0 attribute diffs, all reads Good**, only the LogIt node differs. One bug caught and reverted during verification: compat-side reference registration duplicated quasar's own, breaking recursive address-space walks.