### PR TITLE
OPCUA-3413: UaSession::serverStatus() + populated UaClient::ServerStatus enum

### DIFF
--- a/include/uaclient/uasession.h
+++ b/include/uaclient/uasession.h
@@ -93,7 +93,12 @@ namespace UaClient
 
 enum ServerStatus
 {
-
+    Disconnected,
+    Connected,
+    ConnectionWarningWatchdogTimeout,
+    ConnectionErrorApiReconnect,
+    ServerShutdown,
+    NewSessionCreated
 };
 
 }
@@ -134,6 +139,8 @@ public:
             const CallIn &          callRequest,
             CallOut &               callResponse
         );
+
+    UaClient::ServerStatus serverStatus() const;
 
     UaStatus disconnect(
             ServiceSettings &       serviceSettings,

--- a/src/uaclient/uasession.cpp
+++ b/src/uaclient/uasession.cpp
@@ -132,6 +132,21 @@ UaStatus UaSession::connect(
  * TODO: serviceSettings,
  * TODO: deleteSubscriptions
  */
+UaClient::ServerStatus UaSession::serverStatus() const
+{
+    if (!m_client)
+        return UaClient::Disconnected;
+    UA_SecureChannelState channelState;
+    UA_SessionState sessionState;
+    UA_StatusCode connectStatus;
+    UA_Client_getState(m_client, &channelState, &sessionState, &connectStatus);
+    if (connectStatus != UA_STATUSCODE_GOOD)
+        return UaClient::ConnectionErrorApiReconnect;
+    if (sessionState == UA_SESSIONSTATE_ACTIVATED)
+        return UaClient::Connected;
+    return UaClient::Disconnected;
+}
+
 UaStatus UaSession::disconnect(
         ServiceSettings &,
         OpcUa_Boolean

--- a/test/src/async_io_test.cpp
+++ b/test/src/async_io_test.cpp
@@ -190,3 +190,18 @@ TEST(AsyncIoTest, inlineCompletionStaysSynchronous)
     ServiceSettings settings;
     session.disconnect(settings, OpcUa_True);
 }
+
+TEST(AsyncIoTest, serverStatusReflectsConnectionState)
+{
+    TestServerFixture fixture;
+
+    UaClientSdk::UaSession session;
+    EXPECT_EQ(UaClientSdk::UaClient::Disconnected, session.serverStatus());
+    UaClientSdk::SessionConnectInfo info;
+    UaClientSdk::SessionSecurityInfo security;
+    ASSERT_TRUE(session.connect("opc.tcp://127.0.0.1:4841", info, security, nullptr).isGood());
+    EXPECT_EQ(UaClientSdk::UaClient::Connected, session.serverStatus());
+    ServiceSettings settings;
+    session.disconnect(settings, OpcUa_True);
+    EXPECT_EQ(UaClientSdk::UaClient::Disconnected, session.serverStatus());
+}


### PR DESCRIPTION
Client-side UA-SDK surface ([OPCUA-3413](https://its.cern.ch/jira/browse/OPCUA-3413)): `UaClient::ServerStatus` populated with the UA-SDK 1.6.5 members; `serverStatus()` implemented over `UA_Client_getState` (activated session → Connected; bad connectStatus → ConnectionErrorApiReconnect; else Disconnected). Used by ltdb's supervision loops. Verified live in the gtest fixture (connect/disconnect cycle), 50/50.