### PR TITLE
Pin LogIt to the v1.0.x maintenance branch

### DIFF
--- a/LogIt.cmake
+++ b/LogIt.cmake
@@ -24,7 +24,7 @@
 
 
 function ( fetch_LogIt )
-  SET (LOGIT_VERSION "v1.0.0")
+  SET (LOGIT_VERSION "v1.0.x")
   message(STATUS "fetching LogIt from github. *NOTE* fetching version [${LOGIT_VERSION}]")
   Open62541CompatFetchContent_Declare(
     LogIt


### PR DESCRIPTION
Pins `LOGIT_VERSION` to LogIt's new **`v1.0.x` maintenance branch** = v1.0.0 + three surgical fixes (+13/−7 over 4 files):

1. `cmake_minimum_required` 2.8 → **3.16** (called before `project()`) — the floor quasar core/mule/compat already promise ([OPCUA-3365](https://its.cern.ch/jira/browse/OPCUA-3365)); CMake 4.x hard-rejects every existing LogIt tag ([OPCUA-3336](https://its.cern.ch/jira/browse/OPCUA-3336) issue 1)
2. `BUILD_INTERFACE`/`INSTALL_INTERFACE` on the public include dir (3336 issue 2 — the NSW/tdaq `install(EXPORT)` break)
3. Warning-clean sink headers (LogIt PR #17 cherry-pick — strict `-Werror` servers, DCS-614)

LogIt master keeps PR #17 open for its next release; the maintenance branch is the consumable bridge.

**Verification**: LogIt configures+builds under CMake **3.16.3** (ubuntu 20.04), **3.31.8** (Alma 9) and **4.0.3** (v1.0.0 control hard-fails there with "Compatibility with CMake < 3.5 has been removed"); an `install(EXPORT)` consumer generates cleanly; compat full standalone build + **50/50** gtest with this pin.